### PR TITLE
Concurrent upload and easy DX for faucet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,6 +1407,7 @@ dependencies = [
  "anyhow",
  "clap 4.5.18",
  "cosmwasm-std 2.1.4",
+ "deadpool",
  "dotenvy",
  "futures",
  "lavs-mock-operators",
@@ -2532,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "layer-climb"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=94b4c980c9acb6e456d00a81b096ead4ad170e09#94b4c980c9acb6e456d00a81b096ead4ad170e09"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=ff3bfb6de20f52ba78dccf1545df11600f15f8e5#ff3bfb6de20f52ba78dccf1545df11600f15f8e5"
 dependencies = [
  "layer-climb-address",
  "layer-climb-config",
@@ -2543,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-address"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=94b4c980c9acb6e456d00a81b096ead4ad170e09#94b4c980c9acb6e456d00a81b096ead4ad170e09"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=ff3bfb6de20f52ba78dccf1545df11600f15f8e5#ff3bfb6de20f52ba78dccf1545df11600f15f8e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2567,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-config"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=94b4c980c9acb6e456d00a81b096ead4ad170e09#94b4c980c9acb6e456d00a81b096ead4ad170e09"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=ff3bfb6de20f52ba78dccf1545df11600f15f8e5#ff3bfb6de20f52ba78dccf1545df11600f15f8e5"
 dependencies = [
  "anyhow",
  "serde",
@@ -2576,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-core"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=94b4c980c9acb6e456d00a81b096ead4ad170e09#94b4c980c9acb6e456d00a81b096ead4ad170e09"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=ff3bfb6de20f52ba78dccf1545df11600f15f8e5#ff3bfb6de20f52ba78dccf1545df11600f15f8e5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2608,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-proto"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=94b4c980c9acb6e456d00a81b096ead4ad170e09#94b4c980c9acb6e456d00a81b096ead4ad170e09"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=ff3bfb6de20f52ba78dccf1545df11600f15f8e5#ff3bfb6de20f52ba78dccf1545df11600f15f8e5"
 dependencies = [
  "anyhow",
  "cosmos-sdk-proto 0.25.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "layer-climb"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=ff3bfb6de20f52ba78dccf1545df11600f15f8e5#ff3bfb6de20f52ba78dccf1545df11600f15f8e5"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=8953b5331cc0a05529f90ca0e68d03a8211254f7#8953b5331cc0a05529f90ca0e68d03a8211254f7"
 dependencies = [
  "layer-climb-address",
  "layer-climb-config",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-address"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=ff3bfb6de20f52ba78dccf1545df11600f15f8e5#ff3bfb6de20f52ba78dccf1545df11600f15f8e5"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=8953b5331cc0a05529f90ca0e68d03a8211254f7#8953b5331cc0a05529f90ca0e68d03a8211254f7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-config"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=ff3bfb6de20f52ba78dccf1545df11600f15f8e5#ff3bfb6de20f52ba78dccf1545df11600f15f8e5"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=8953b5331cc0a05529f90ca0e68d03a8211254f7#8953b5331cc0a05529f90ca0e68d03a8211254f7"
 dependencies = [
  "anyhow",
  "serde",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-core"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=ff3bfb6de20f52ba78dccf1545df11600f15f8e5#ff3bfb6de20f52ba78dccf1545df11600f15f8e5"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=8953b5331cc0a05529f90ca0e68d03a8211254f7#8953b5331cc0a05529f90ca0e68d03a8211254f7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2600,6 +2600,7 @@ dependencies = [
  "tendermint",
  "tendermint-rpc",
  "thiserror",
+ "tokio",
  "toml",
  "tonic",
  "tonic-web-wasm-client",
@@ -2609,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-proto"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=ff3bfb6de20f52ba78dccf1545df11600f15f8e5#ff3bfb6de20f52ba78dccf1545df11600f15f8e5"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=8953b5331cc0a05529f90ca0e68d03a8211254f7#8953b5331cc0a05529f90ca0e68d03a8211254f7"
 dependencies = [
  "anyhow",
  "cosmos-sdk-proto 0.25.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "layer-climb"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=8953b5331cc0a05529f90ca0e68d03a8211254f7#8953b5331cc0a05529f90ca0e68d03a8211254f7"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=9180b2a1d98e7159ff327f0201f299a063fa9023#9180b2a1d98e7159ff327f0201f299a063fa9023"
 dependencies = [
  "layer-climb-address",
  "layer-climb-config",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-address"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=8953b5331cc0a05529f90ca0e68d03a8211254f7#8953b5331cc0a05529f90ca0e68d03a8211254f7"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=9180b2a1d98e7159ff327f0201f299a063fa9023#9180b2a1d98e7159ff327f0201f299a063fa9023"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-config"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=8953b5331cc0a05529f90ca0e68d03a8211254f7#8953b5331cc0a05529f90ca0e68d03a8211254f7"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=9180b2a1d98e7159ff327f0201f299a063fa9023#9180b2a1d98e7159ff327f0201f299a063fa9023"
 dependencies = [
  "anyhow",
  "serde",
@@ -2577,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-core"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=8953b5331cc0a05529f90ca0e68d03a8211254f7#8953b5331cc0a05529f90ca0e68d03a8211254f7"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=9180b2a1d98e7159ff327f0201f299a063fa9023#9180b2a1d98e7159ff327f0201f299a063fa9023"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-proto"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=8953b5331cc0a05529f90ca0e68d03a8211254f7#8953b5331cc0a05529f90ca0e68d03a8211254f7"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=9180b2a1d98e7159ff327f0201f299a063fa9023#9180b2a1d98e7159ff327f0201f299a063fa9023"
 dependencies = [
  "anyhow",
  "cosmos-sdk-proto 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ dotenvy = {version = "0.15.7", features = ["cli"]}
 tracing-subscriber = "0.3.18"
 bip39 = "2.0.0"
 rand = "0.8"
-layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "ff3bfb6de20f52ba78dccf1545df11600f15f8e5"}
+layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "8953b5331cc0a05529f90ca0e68d03a8211254f7"}
 # purposefully left in for now to make debugging easier, will remove eventually:
 # layer-climb = { path = "../climb/packages/layer-climb" }
 deadpool = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,10 @@ dotenvy = {version = "0.15.7", features = ["cli"]}
 tracing-subscriber = "0.3.18"
 bip39 = "2.0.0"
 rand = "0.8"
-layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "94b4c980c9acb6e456d00a81b096ead4ad170e09"}
+layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "ff3bfb6de20f52ba78dccf1545df11600f15f8e5"}
+# purposefully left in for now to make debugging easier, will remove eventually:
+# layer-climb = { path = "../climb/packages/layer-climb" }
+deadpool = "0.12.1"
 
 [profile.release]
 codegen-units    = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ dotenvy = {version = "0.15.7", features = ["cli"]}
 tracing-subscriber = "0.3.18"
 bip39 = "2.0.0"
 rand = "0.8"
-layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "8953b5331cc0a05529f90ca0e68d03a8211254f7"}
+layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "9180b2a1d98e7159ff327f0201f299a063fa9023"}
 # purposefully left in for now to make debugging easier, will remove eventually:
 # layer-climb = { path = "../climb/packages/layer-climb" }
 deadpool = "0.12.1"

--- a/tools/deploy/Cargo.toml
+++ b/tools/deploy/Cargo.toml
@@ -19,3 +19,4 @@ tracing = { workspace = true }
 dotenvy = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
+deadpool = {workspace = true}

--- a/tools/deploy/README.md
+++ b/tools/deploy/README.md
@@ -8,7 +8,8 @@
 
 1. add a `.env` file
 2. give it a `LOCAL_MNEMONIC` for local deployments, `TEST_MNEMONIC` for testnet
-3. see https://github.com/Lay3rLabs/layer-sdk/blob/main/GETTING-STARTED.md#wallet to create a new mnemonic and give it funds
+3. don't have a mnemonic? see https://github.com/Lay3rLabs/layer-sdk/blob/main/GETTING-STARTED.md#wallet to create a new one
+4. funds will be sent automatically from the faucet (if `pre_fund_minimum` is larger than zero, which it is by default)
 
 ### Deploying Contracts
 

--- a/tools/deploy/src/args.rs
+++ b/tools/deploy/src/args.rs
@@ -1,51 +1,21 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{
+    ops::{Deref, DerefMut},
+    path::PathBuf,
+    str::FromStr,
+};
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use clap::{Parser, Subcommand};
 use cosmwasm_std::Coin;
-use layer_climb::prelude::*;
+use deadpool::managed::Pool;
+use layer_climb::{pool::SigningClientPoolManager, prelude::*};
 use serde::{Deserialize, Serialize};
 
 // Args is the thing main _really_ uses, but it depends on CliArgs being parsed first
 pub struct Args {
     pub command: Command,
-    pub client: SigningClient,
-}
-
-impl Args {
-    pub async fn new(cli_args: CliArgs) -> Result<Self> {
-        let env_var_key = match cli_args.target_env {
-            TargetEnvironment::Local => "LOCAL_MNEMONIC",
-            TargetEnvironment::Testnet => "TEST_MNEMONIC",
-        };
-
-        let mnemonic =
-            std::env::var(env_var_key).context(format!("Mnemonic not found at {env_var_key}"))?;
-
-        let configs: Config = serde_json::from_str(include_str!("../config.json"))
-            .context("Failed to parse config")?;
-
-        let chain_config = match cli_args.target_env {
-            TargetEnvironment::Local => configs.chains.local,
-            TargetEnvironment::Testnet => configs.chains.testnet,
-        }
-        .context(format!(
-            "Chain config for environment {:?} not found",
-            cli_args.target_env
-        ))?;
-
-        tracing::info!("Creating signing client...");
-
-        let signer = KeySigner::new_mnemonic_str(&mnemonic, None)?;
-        let client = SigningClient::new(chain_config, signer).await?;
-
-        tracing::info!("Our address is {}", client.addr);
-
-        Ok(Self {
-            command: cli_args.command,
-            client,
-        })
-    }
+    // pool of additional clients for concurrent operations
+    pub client_pool: Pool<SigningClientPoolManager>,
 }
 
 #[derive(Parser)]
@@ -59,8 +29,94 @@ pub struct CliArgs {
     //#[arg(long, value_enum, default_value_t = LogLevel::Debug)]
     pub log_level: LogLevel,
 
+    /// max concurrent accounts in the pool
+    #[arg(long, default_value_t = 3)]
+    pub max_concurrent_accounts: u32,
+
+    /// minimum balance set for pre-funding all the concurrent accounts in the pool
+    /// set to 0 if you don't want any pre-funding at all
+    #[arg(long, default_value_t = 1_000_000)]
+    pub pre_fund_minimum: u128,
+
     #[command(subcommand)]
     pub command: Command,
+}
+
+impl Args {
+    pub async fn new(cli_args: CliArgs) -> Result<Self> {
+        let mnemonic_var = match cli_args.target_env {
+            TargetEnvironment::Local => "LOCAL_MNEMONIC",
+            TargetEnvironment::Testnet => "TEST_MNEMONIC",
+        };
+
+        let mnemonic =
+            std::env::var(mnemonic_var).context(format!("Mnemonic not found at {mnemonic_var}"))?;
+
+        let configs: Config = serde_json::from_str(include_str!("../config.json"))
+            .context("Failed to parse config")?;
+
+        let chain_config = match cli_args.target_env {
+            TargetEnvironment::Local => configs.chains.local,
+            TargetEnvironment::Testnet => configs.chains.testnet,
+        }
+        .context(format!(
+            "Chain config for environment {:?} not found",
+            cli_args.target_env
+        ))?;
+
+        let client_pool: Pool<SigningClientPoolManager> = Pool::builder(
+            SigningClientPoolManager::new_mnemonic(mnemonic, chain_config.clone(), None),
+        )
+        .max_size(cli_args.max_concurrent_accounts.try_into()?)
+        .build()
+        .context("Failed to create client pool")?;
+
+        // pre-fund accounts
+        if cli_args.pre_fund_minimum > 0 {
+            let faucet_signer = KeySigner::new_mnemonic_str(&configs.faucet.mnemonic, None)?;
+            let faucet = SigningClient::new(chain_config, faucet_signer).await?;
+            let faucet_balance = faucet
+                .querier
+                .balance(faucet.addr.clone(), None)
+                .await?
+                .unwrap_or_default();
+
+            tracing::info!(
+                "Prefunding {} accounts from faucet at {} with balance of {}",
+                cli_args.max_concurrent_accounts,
+                faucet.addr,
+                faucet_balance
+            );
+
+            let clients = futures::future::try_join_all(
+                (0..cli_args.max_concurrent_accounts)
+                    .into_iter()
+                    .map(|_| client_pool.get()),
+            )
+            .await
+            .map_err(|e| anyhow!("{e:?}"))?;
+
+            // these are sequential because we only have one faucet
+            for client in clients {
+                let balance = client
+                    .querier
+                    .balance(client.addr.clone(), None)
+                    .await?
+                    .unwrap_or_default();
+
+                if balance < cli_args.pre_fund_minimum {
+                    let amount = cli_args.pre_fund_minimum - balance;
+                    tracing::info!("pre-fund: sending {} to {}", amount, client.addr);
+                    faucet.transfer(None, amount, &client.addr, None).await?;
+                }
+            }
+        }
+
+        Ok(Self {
+            command: cli_args.command,
+            client_pool,
+        })
+    }
 }
 
 #[derive(Copy, Clone, Debug, clap::ValueEnum)]

--- a/tools/deploy/src/main.rs
+++ b/tools/deploy/src/main.rs
@@ -1,12 +1,14 @@
 #![allow(warnings)]
 mod args;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Ok, Result};
 use args::{Args, CliArgs, Command};
 use clap::Parser;
+use deadpool::managed::Pool;
+use futures::try_join;
 use lavs_task_queue::msg::{Requestor, TimeoutInfo};
-use layer_climb::prelude::*;
-use std::{fs, os::unix::net};
+use layer_climb::{pool::SigningClientPoolManager, prelude::*};
+use std::{fs, os::unix::net, path::PathBuf};
 use tracing;
 use tracing_subscriber;
 
@@ -29,55 +31,26 @@ async fn main() -> Result<()> {
     // now we can get our real args :)
     let args = Args::new(cli_args).await?;
 
-    let Args { command, client } = args;
+    let Args {
+        command,
+        client_pool,
+    } = args;
 
     match &command {
         Command::DeployContracts { artifacts_path } => {
             tracing::info!("Uploading contracts from {:?}", artifacts_path);
-            let operators_path = artifacts_path.join("lavs_mock_operators.wasm");
-            let task_queue_path = artifacts_path.join("lavs_task_queue.wasm");
-            let verifier_simple_path = artifacts_path.join("lavs_verifier_simple.wasm");
 
-            if !operators_path.exists() {
-                bail!(
-                    "Mock Operators contract not found at {} (try running collect_wasm.sh)",
-                    operators_path.display()
-                );
-            }
-            if !task_queue_path.exists() {
-                bail!(
-                    "Task Queue contract not found at {} (try running collect_wasm.sh)",
-                    task_queue_path.display()
-                );
-            }
-            if !verifier_simple_path.exists() {
-                bail!(
-                    "Verifier Simple contract not found at {} (try running collect_wasm.sh)",
-                    verifier_simple_path.display()
-                );
-            }
+            let wasm_files = WasmFiles::read(artifacts_path.clone()).await?;
 
-            // TODO - fix account sequence stuff in climb so we can do this all concurrently
-            let operators_wasm = tokio::fs::read(operators_path).await?;
-            let (operators_code_id, tx_resp) =
-                client.contract_upload_file(operators_wasm, None).await?;
-            tracing::info!("Mock Operators Tx Hash: {}", tx_resp.txhash);
-            tracing::info!("Mock Operators Code ID: {}", operators_code_id);
-
-            let task_queue_wasm = tokio::fs::read(task_queue_path).await?;
-            let (task_queue_code_id, tx_resp) =
-                client.contract_upload_file(task_queue_wasm, None).await?;
-            tracing::info!("Task Queue Tx Hash: {}", tx_resp.txhash);
-            tracing::info!("Task Queue Code ID: {}", task_queue_code_id);
-
-            let verifier_simple_wasm = tokio::fs::read(verifier_simple_path).await?;
-            let (verifier_code_id, tx_resp) = client
-                .contract_upload_file(verifier_simple_wasm, None)
-                .await?;
-            tracing::info!("Verifier Simple Tx Hash: {}", tx_resp.txhash);
-            tracing::info!("Verifier Simple Code ID: {}", verifier_code_id);
+            let CodeIds {
+                operators: operators_code_id,
+                task_queue: task_queue_code_id,
+                verifier_simple: verifier_code_id,
+            } = CodeIds::upload(wasm_files, client_pool.clone()).await?;
 
             tracing::info!("Contracts all uploaded successfully, instantiating...");
+
+            let client = client_pool.get().await.map_err(|e| anyhow!("{e:?}"))?;
 
             let (operators_addr, tx_resp) = client
                 .contract_instantiate(
@@ -145,4 +118,116 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+struct WasmFiles {
+    operators: Vec<u8>,
+    task_queue: Vec<u8>,
+    verifier_simple: Vec<u8>,
+}
+
+impl WasmFiles {
+    pub async fn read(artifacts_path: PathBuf) -> Result<Self> {
+        let operators_path = artifacts_path.join("lavs_mock_operators.wasm");
+        let task_queue_path = artifacts_path.join("lavs_task_queue.wasm");
+        let verifier_simple_path = artifacts_path.join("lavs_verifier_simple.wasm");
+
+        if !operators_path.exists() {
+            bail!(
+                "Mock Operators contract not found at {} (try running collect_wasm.sh)",
+                operators_path.display()
+            );
+        }
+        if !task_queue_path.exists() {
+            bail!(
+                "Task Queue contract not found at {} (try running collect_wasm.sh)",
+                task_queue_path.display()
+            );
+        }
+        if !verifier_simple_path.exists() {
+            bail!(
+                "Verifier Simple contract not found at {} (try running collect_wasm.sh)",
+                verifier_simple_path.display()
+            );
+        }
+
+        let (operators, task_queue, verifier_simple) = try_join!(
+            tokio::fs::read(operators_path),
+            tokio::fs::read(task_queue_path),
+            tokio::fs::read(verifier_simple_path)
+        )?;
+
+        Ok(Self {
+            operators,
+            task_queue,
+            verifier_simple,
+        })
+    }
+}
+
+struct CodeIds {
+    operators: u64,
+    task_queue: u64,
+    verifier_simple: u64,
+}
+
+impl CodeIds {
+    pub async fn upload(
+        files: WasmFiles,
+        client_pool: Pool<SigningClientPoolManager>,
+    ) -> Result<Self> {
+        let WasmFiles {
+            operators: operators_wasm,
+            task_queue: task_queue_wasm,
+            verifier_simple: verifier_simple_wasm,
+        } = files;
+
+        let (operators_code_id, task_queue_code_id, verifier_code_id) = try_join!(
+            {
+                let client_pool = client_pool.clone();
+                async move {
+                    let client = client_pool.get().await.map_err(|e| anyhow!("{e:?}"))?;
+
+                    tracing::info!("Uploading Mock Operators from: {}", client.addr);
+                    let (code_id, tx_resp) =
+                        client.contract_upload_file(operators_wasm, None).await?;
+                    tracing::info!("Mock Operators Tx Hash: {}", tx_resp.txhash);
+                    tracing::info!("Mock Operators Code ID: {}", code_id);
+                    Ok(code_id)
+                }
+            },
+            {
+                let client_pool = client_pool.clone();
+                async move {
+                    let client = client_pool.get().await.map_err(|e| anyhow!("{e:?}"))?;
+
+                    tracing::info!("Uploading Task Queue from: {}", client.addr);
+                    let (code_id, tx_resp) =
+                        client.contract_upload_file(task_queue_wasm, None).await?;
+                    tracing::info!("Task Queue Tx Hash: {}", tx_resp.txhash);
+                    tracing::info!("Task Queue Code ID: {}", code_id);
+                    Ok(code_id)
+                }
+            },
+            {
+                let client_pool = client_pool.clone();
+                async move {
+                    let client = client_pool.get().await.map_err(|e| anyhow!("{e:?}"))?;
+                    tracing::info!("Uploading Simple Verifier from: {}", client.addr);
+                    let (code_id, tx_resp) = client
+                        .contract_upload_file(verifier_simple_wasm, None)
+                        .await?;
+                    tracing::info!("Simple Verifier Tx Hash: {}", tx_resp.txhash);
+                    tracing::info!("Simple Verifier Code ID: {}", code_id);
+                    Ok(code_id)
+                }
+            }
+        )?;
+
+        Ok(Self {
+            operators: operators_code_id,
+            task_queue: task_queue_code_id,
+            verifier_simple: verifier_code_id,
+        })
+    }
 }


### PR DESCRIPTION
_PR chain note: followed by https://github.com/Lay3rLabs/avs-toolkit/pull/28_

The settings are controllable via CLI args, but by default this will:

1) Create a pool with maximum 3 clients
2) Set the [minimum balance maintainer](https://github.com/Lay3rLabs/climb/blob/109fea5d48045d2fdf30ce83cb323c16629c9f6f/packages/layer-climb-core/src/pool.rs#L41) to a threshhold of 200_000 and amount of 2_000_000
3) The fun part - [run all these clients concurrently for uploading](https://github.com/Lay3rLabs/avs-toolkit/blob/fcb6f1c360a8ce973c6cdbe6159839ece54fed4c/tools/deploy/src/main.rs#L185)

The API is super simple, once the pool exists, as long as there's no _logical_ exclusions, clients can be used in `join`, `select`, whatever - it's all just Rust async via the `deadpool` crate

It's not unlikely to expect this to keep paying off more as we build up tests, e.g. it will be trivial to run on-chain tests in parallel (just share it among all the test functions!)

What's also nice is that the "minimum balance maintainer" just tops up to tops-up needed... so if one of the derivations has more or less funds than the others, it all just works smoothly

(the pool manager itself is part of `climb`, very straightforward, the key is that it just [increases the derivation path each time it needs a new client](https://github.com/Lay3rLabs/climb/blob/109fea5d48045d2fdf30ce83cb323c16629c9f6f/packages/layer-climb-core/src/pool.rs#L77), and deadpool does its magic of returning to the pool.)