### PR TITLE
Task queue add

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "deadpool",
  "dotenvy",
  "futures",
+ "lavs-apis",
  "lavs-mock-operators",
  "lavs-task-queue",
  "lavs-verifier-simple",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "layer-climb"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=9180b2a1d98e7159ff327f0201f299a063fa9023#9180b2a1d98e7159ff327f0201f299a063fa9023"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d9382bd2ea9add6097220f808dc4d99db2958fc3#d9382bd2ea9add6097220f808dc4d99db2958fc3"
 dependencies = [
  "layer-climb-address",
  "layer-climb-config",
@@ -2555,7 +2555,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-address"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=9180b2a1d98e7159ff327f0201f299a063fa9023#9180b2a1d98e7159ff327f0201f299a063fa9023"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d9382bd2ea9add6097220f808dc4d99db2958fc3#d9382bd2ea9add6097220f808dc4d99db2958fc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-config"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=9180b2a1d98e7159ff327f0201f299a063fa9023#9180b2a1d98e7159ff327f0201f299a063fa9023"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d9382bd2ea9add6097220f808dc4d99db2958fc3#d9382bd2ea9add6097220f808dc4d99db2958fc3"
 dependencies = [
  "anyhow",
  "serde",
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-core"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=9180b2a1d98e7159ff327f0201f299a063fa9023#9180b2a1d98e7159ff327f0201f299a063fa9023"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d9382bd2ea9add6097220f808dc4d99db2958fc3#d9382bd2ea9add6097220f808dc4d99db2958fc3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2621,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-proto"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=9180b2a1d98e7159ff327f0201f299a063fa9023#9180b2a1d98e7159ff327f0201f299a063fa9023"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d9382bd2ea9add6097220f808dc4d99db2958fc3#d9382bd2ea9add6097220f808dc4d99db2958fc3"
 dependencies = [
  "anyhow",
  "cosmos-sdk-proto 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ dotenvy = {version = "0.15.7", features = ["cli"]}
 tracing-subscriber = "0.3.18"
 bip39 = "2.0.0"
 rand = "0.8"
-layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "9180b2a1d98e7159ff327f0201f299a063fa9023"}
+layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "d9382bd2ea9add6097220f808dc4d99db2958fc3"}
 # purposefully left in for now to make debugging easier, will remove eventually:
 # layer-climb = { path = "../climb/packages/layer-climb" }
 deadpool = "0.12.1"

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 lavs-mock-operators = {workspace = true}
 lavs-verifier-simple = {workspace = true}
 lavs-task-queue = {workspace = true}
+lavs-apis = { workspace = true }
 layer-climb = {workspace = true}
 cosmwasm-std = { workspace = true }
 serde = { workspace = true }

--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -50,7 +50,7 @@ pub enum Command {
 
 #[derive(Clone, Args)]
 pub struct TaskQueueArgs {
-    /// Task queue address. If not provided, then it will be read 
+    /// Task queue address. If not provided, then it will be read
     /// from the environment variable LOCAL_TASK_QUEUE_ADDRESS or TEST_TASK_QUEUE_ADDRESS
     /// depending on the target environment
     #[clap(long)]

--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -50,17 +50,29 @@ pub enum Command {
 
 #[derive(Clone, Args)]
 pub struct TaskQueueArgs {
+    /// Task queue address. If not provided, then it will be read 
+    /// from the environment variable LOCAL_TASK_QUEUE_ADDRESS or TEST_TASK_QUEUE_ADDRESS
+    /// depending on the target environment
+    #[clap(long)]
+    pub address: Option<String>,
+
     #[command(subcommand)]
-    command: TaskQueueCommand,
+    pub command: TaskQueueCommand,
 }
 
 #[derive(Clone, Subcommand)]
 pub enum TaskQueueCommand {
     /// Commands for task queue
     AddTask {
-        // set the default
+        /// The body of the task, must be valid JSON
         #[clap(short, long)]
-        body: serde_json::Value,
+        body: String,
+        /// Human-readable description of the task
+        #[clap(short, long)]
+        description: String,
+        /// Specify a task timeout, or use the default
+        #[clap(short, long)]
+        timeout: Option<u64>,
     },
 }
 

--- a/tools/cli/src/commands/deploy.rs
+++ b/tools/cli/src/commands/deploy.rs
@@ -137,10 +137,7 @@ struct CodeIds {
 }
 
 impl CodeIds {
-    pub async fn upload(
-        ctx: &AppContext,
-        files: WasmFiles,
-    ) -> Result<Self> {
+    pub async fn upload(ctx: &AppContext, files: WasmFiles) -> Result<Self> {
         let WasmFiles {
             operators: operators_wasm,
             task_queue: task_queue_wasm,
@@ -151,7 +148,7 @@ impl CodeIds {
             {
                 let ctx = ctx.clone();
                 async move {
-                    let client = ctx.get_client().await?; 
+                    let client = ctx.get_client().await?;
 
                     tracing::debug!("Uploading Mock Operators from: {}", client.addr);
                     let (code_id, tx_resp) =
@@ -164,7 +161,7 @@ impl CodeIds {
             {
                 let ctx = ctx.clone();
                 async move {
-                    let client = ctx.get_client().await?; 
+                    let client = ctx.get_client().await?;
 
                     tracing::debug!("Uploading Task Queue from: {}", client.addr);
                     let (code_id, tx_resp) =
@@ -177,7 +174,7 @@ impl CodeIds {
             {
                 let ctx = ctx.clone();
                 async move {
-                    let client = ctx.get_client().await?; 
+                    let client = ctx.get_client().await?;
 
                     tracing::debug!("Uploading Simple Verifier from: {}", client.addr);
                     let (code_id, tx_resp) = client

--- a/tools/cli/src/commands/deploy.rs
+++ b/tools/cli/src/commands/deploy.rs
@@ -1,8 +1,6 @@
 use crate::context::AppContext;
-use anyhow::{anyhow, bail, Result};
-use deadpool::managed::Pool;
+use anyhow::{bail, Result};
 use lavs_task_queue::msg::{Requestor, TimeoutInfo};
-use layer_climb::prelude::*;
 use std::path::PathBuf;
 use tokio::try_join;
 
@@ -15,11 +13,11 @@ pub async fn deploy_contracts(ctx: AppContext, artifacts_path: PathBuf) -> Resul
         operators: operators_code_id,
         task_queue: task_queue_code_id,
         verifier_simple: verifier_code_id,
-    } = CodeIds::upload(wasm_files, ctx.client_pool.clone()).await?;
+    } = CodeIds::upload(&ctx, wasm_files).await?;
 
     tracing::debug!("Contracts all uploaded successfully, instantiating...");
 
-    let client = ctx.client_pool.get().await.map_err(|e| anyhow!("{e:?}"))?;
+    let client = ctx.get_client().await?;
 
     let (operators_addr, tx_resp) = client
         .contract_instantiate(
@@ -140,8 +138,8 @@ struct CodeIds {
 
 impl CodeIds {
     pub async fn upload(
+        ctx: &AppContext,
         files: WasmFiles,
-        client_pool: Pool<SigningClientPoolManager>,
     ) -> Result<Self> {
         let WasmFiles {
             operators: operators_wasm,
@@ -151,9 +149,9 @@ impl CodeIds {
 
         let (operators_code_id, task_queue_code_id, verifier_code_id) = try_join!(
             {
-                let client_pool = client_pool.clone();
+                let ctx = ctx.clone();
                 async move {
-                    let client = client_pool.get().await.map_err(|e| anyhow!("{e:?}"))?;
+                    let client = ctx.get_client().await?; 
 
                     tracing::debug!("Uploading Mock Operators from: {}", client.addr);
                     let (code_id, tx_resp) =
@@ -164,9 +162,9 @@ impl CodeIds {
                 }
             },
             {
-                let client_pool = client_pool.clone();
+                let ctx = ctx.clone();
                 async move {
-                    let client = client_pool.get().await.map_err(|e| anyhow!("{e:?}"))?;
+                    let client = ctx.get_client().await?; 
 
                     tracing::debug!("Uploading Task Queue from: {}", client.addr);
                     let (code_id, tx_resp) =
@@ -177,9 +175,10 @@ impl CodeIds {
                 }
             },
             {
-                let client_pool = client_pool.clone();
+                let ctx = ctx.clone();
                 async move {
-                    let client = client_pool.get().await.map_err(|e| anyhow!("{e:?}"))?;
+                    let client = ctx.get_client().await?; 
+
                     tracing::debug!("Uploading Simple Verifier from: {}", client.addr);
                     let (code_id, tx_resp) = client
                         .contract_upload_file(verifier_simple_wasm, None)

--- a/tools/cli/src/commands/mod.rs
+++ b/tools/cli/src/commands/mod.rs
@@ -1,1 +1,2 @@
 pub mod deploy;
+pub mod task_queue;

--- a/tools/cli/src/commands/task_queue.rs
+++ b/tools/cli/src/commands/task_queue.rs
@@ -1,0 +1,64 @@
+use crate::{args::{TargetEnvironment, TaskQueueArgs}, context::AppContext};
+use lavs_apis::id::TaskId;
+use lavs_task_queue::msg::{ConfigResponse, CustomExecuteMsg, CustomQueryMsg, ExecuteMsg, QueryMsg, Requestor};
+use layer_climb::{prelude::*, proto::abci::TxResponse};
+use anyhow::{Context, Result};
+
+pub struct TaskQueue {
+    pub ctx: AppContext,
+    pub contract_addr: Address,
+}
+
+impl TaskQueue {
+    pub async fn new(ctx: AppContext, task_queue_args: &TaskQueueArgs) -> Result<Self> {
+        let addr_string = match task_queue_args.address.clone() {
+            Some(x) => x,
+            None => {
+                match ctx.args.target_env {
+                    TargetEnvironment::Local => std::env::var("LOCAL_TASK_QUEUE_ADDRESS").context("LOCAL_TASK_QUEUE_ADDRESS not found")?,
+                    TargetEnvironment::Testnet => std::env::var("TEST_TASK_QUEUE_ADDRESS").context("TEST_TASK_QUEUE_ADDRESS not found")?,
+                }
+            }
+        };
+
+        let contract_addr = ctx.chain_config.parse_address(&addr_string)?;
+
+        Ok(Self {
+            ctx,
+            contract_addr,
+        })
+    }
+
+    pub async fn add_task(&self, body: String, description: String, timeout: Option<u64>) -> Result<(TaskId, TxResponse)> {
+        let payload = serde_json::from_str(&body).context("Failed to parse body into JSON")?;
+
+        let contract_config: ConfigResponse = self.ctx.get_client().await?.querier.contract_smart(
+            &self.contract_addr,
+            &QueryMsg::Custom(CustomQueryMsg::Config {  }),
+        ).await?;
+
+        let payment = match contract_config.requestor {
+            Requestor::OpenPayment(coin) => vec![new_coin(coin.amount, coin.denom)],
+            _ => Vec::new() 
+        };
+
+        let tx_resp = self.ctx.get_client().await?.contract_execute(
+            &self.contract_addr,
+            &ExecuteMsg::Custom(CustomExecuteMsg::Create { 
+                description, 
+                timeout, 
+                payload
+            }),
+            payment,
+            None,
+        ).await?;
+
+        let task_id:TaskId = CosmosTxEvents::from(&tx_resp).attr_first("wasm", "task_id")?.value().parse()?;
+
+        tracing::info!("Task added with id: {task_id}");
+        tracing::info!("Tx hash: {}", tx_resp.txhash);
+
+        Ok((task_id, tx_resp))
+    }
+
+}

--- a/tools/cli/src/commands/task_queue.rs
+++ b/tools/cli/src/commands/task_queue.rs
@@ -4,9 +4,7 @@ use crate::{
 };
 use anyhow::{bail, Context, Result};
 use lavs_apis::id::TaskId;
-use lavs_task_queue::msg::{
-    ConfigResponse, CustomExecuteMsg, CustomQueryMsg, ExecuteMsg, QueryMsg, Requestor,
-};
+use lavs_task_queue::msg::{ConfigResponse, CustomExecuteMsg, CustomQueryMsg, QueryMsg, Requestor};
 use layer_climb::{prelude::*, proto::abci::TxResponse};
 
 pub struct TaskQueue {
@@ -66,11 +64,11 @@ impl TaskQueue {
             .await?
             .contract_execute(
                 &self.contract_addr,
-                &ExecuteMsg::Custom(CustomExecuteMsg::Create {
+                &CustomExecuteMsg::Create {
                     description,
                     timeout,
                     payload,
-                }),
+                },
                 payment,
                 None,
             )

--- a/tools/cli/src/commands/task_queue.rs
+++ b/tools/cli/src/commands/task_queue.rs
@@ -79,8 +79,8 @@ impl TaskQueue {
             .value()
             .parse()?;
 
-        tracing::info!("Task added with id: {task_id}");
-        tracing::info!("Tx hash: {}", tx_resp.txhash);
+        tracing::debug!("Task added with id: {task_id}");
+        tracing::debug!("Tx hash: {}", tx_resp.txhash);
 
         Ok((task_id, tx_resp))
     }

--- a/tools/cli/src/commands/task_queue.rs
+++ b/tools/cli/src/commands/task_queue.rs
@@ -1,8 +1,13 @@
-use crate::{args::{TargetEnvironment, TaskQueueArgs}, context::AppContext};
-use lavs_apis::id::TaskId;
-use lavs_task_queue::msg::{ConfigResponse, CustomExecuteMsg, CustomQueryMsg, ExecuteMsg, QueryMsg, Requestor};
-use layer_climb::{prelude::*, proto::abci::TxResponse};
+use crate::{
+    args::{TargetEnvironment, TaskQueueArgs},
+    context::AppContext,
+};
 use anyhow::{Context, Result};
+use lavs_apis::id::TaskId;
+use lavs_task_queue::msg::{
+    ConfigResponse, CustomExecuteMsg, CustomQueryMsg, ExecuteMsg, QueryMsg, Requestor,
+};
+use layer_climb::{prelude::*, proto::abci::TxResponse};
 
 pub struct TaskQueue {
     pub ctx: AppContext,
@@ -13,52 +18,67 @@ impl TaskQueue {
     pub async fn new(ctx: AppContext, task_queue_args: &TaskQueueArgs) -> Result<Self> {
         let addr_string = match task_queue_args.address.clone() {
             Some(x) => x,
-            None => {
-                match ctx.args.target_env {
-                    TargetEnvironment::Local => std::env::var("LOCAL_TASK_QUEUE_ADDRESS").context("LOCAL_TASK_QUEUE_ADDRESS not found")?,
-                    TargetEnvironment::Testnet => std::env::var("TEST_TASK_QUEUE_ADDRESS").context("TEST_TASK_QUEUE_ADDRESS not found")?,
-                }
-            }
+            None => match ctx.args.target_env {
+                TargetEnvironment::Local => std::env::var("LOCAL_TASK_QUEUE_ADDRESS")
+                    .context("LOCAL_TASK_QUEUE_ADDRESS not found")?,
+                TargetEnvironment::Testnet => std::env::var("TEST_TASK_QUEUE_ADDRESS")
+                    .context("TEST_TASK_QUEUE_ADDRESS not found")?,
+            },
         };
 
         let contract_addr = ctx.chain_config.parse_address(&addr_string)?;
 
-        Ok(Self {
-            ctx,
-            contract_addr,
-        })
+        Ok(Self { ctx, contract_addr })
     }
 
-    pub async fn add_task(&self, body: String, description: String, timeout: Option<u64>) -> Result<(TaskId, TxResponse)> {
+    pub async fn add_task(
+        &self,
+        body: String,
+        description: String,
+        timeout: Option<u64>,
+    ) -> Result<(TaskId, TxResponse)> {
         let payload = serde_json::from_str(&body).context("Failed to parse body into JSON")?;
 
-        let contract_config: ConfigResponse = self.ctx.get_client().await?.querier.contract_smart(
-            &self.contract_addr,
-            &QueryMsg::Custom(CustomQueryMsg::Config {  }),
-        ).await?;
+        let contract_config: ConfigResponse = self
+            .ctx
+            .get_client()
+            .await?
+            .querier
+            .contract_smart(
+                &self.contract_addr,
+                &QueryMsg::Custom(CustomQueryMsg::Config {}),
+            )
+            .await?;
 
         let payment = match contract_config.requestor {
             Requestor::OpenPayment(coin) => vec![new_coin(coin.amount, coin.denom)],
-            _ => Vec::new() 
+            _ => Vec::new(),
         };
 
-        let tx_resp = self.ctx.get_client().await?.contract_execute(
-            &self.contract_addr,
-            &ExecuteMsg::Custom(CustomExecuteMsg::Create { 
-                description, 
-                timeout, 
-                payload
-            }),
-            payment,
-            None,
-        ).await?;
+        let tx_resp = self
+            .ctx
+            .get_client()
+            .await?
+            .contract_execute(
+                &self.contract_addr,
+                &ExecuteMsg::Custom(CustomExecuteMsg::Create {
+                    description,
+                    timeout,
+                    payload,
+                }),
+                payment,
+                None,
+            )
+            .await?;
 
-        let task_id:TaskId = CosmosTxEvents::from(&tx_resp).attr_first("wasm", "task_id")?.value().parse()?;
+        let task_id: TaskId = CosmosTxEvents::from(&tx_resp)
+            .attr_first("wasm", "task_id")?
+            .value()
+            .parse()?;
 
         tracing::info!("Task added with id: {task_id}");
         tracing::info!("Tx hash: {}", tx_resp.txhash);
 
         Ok((task_id, tx_resp))
     }
-
 }

--- a/tools/cli/src/context.rs
+++ b/tools/cli/src/context.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use deadpool::managed::{Object, Pool};
 use layer_climb::{pool::SigningClientPoolManager, prelude::*};
 
@@ -78,12 +78,15 @@ impl AppContext {
             .build()
             .context("Failed to create client pool")?;
 
-        Ok(Self { args: Arc::new(args), chain_config: Arc::new(chain_config), client_pool })
+        Ok(Self {
+            args: Arc::new(args),
+            chain_config: Arc::new(chain_config),
+            client_pool,
+        })
     }
 
     // small helper to make error handling nicer
     pub async fn get_client(&self) -> Result<Object<SigningClientPoolManager>> {
         self.client_pool.get().await.map_err(|e| anyhow!("{e:?}"))
     }
-
 }

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -4,9 +4,9 @@ mod config;
 mod context;
 
 use anyhow::Result;
-use args::{CliArgs, Command};
+use args::{CliArgs, Command, TaskQueueCommand};
 use clap::Parser;
-use commands::deploy::deploy_contracts;
+use commands::{deploy::deploy_contracts, task_queue::TaskQueue};
 use context::AppContext;
 
 #[tokio::main]
@@ -32,7 +32,15 @@ async fn main() -> Result<()> {
         Command::DeployContracts { artifacts_path } => {
             deploy_contracts(ctx, artifacts_path).await?;
         }
-        Command::TaskQueue(_task_queue_args) => {}
+        Command::TaskQueue(task_queue_args) => {
+            let task_queue = TaskQueue::new(ctx.clone(), &task_queue_args).await?;
+
+            match task_queue_args.command {
+                TaskQueueCommand::AddTask { body, description, timeout} => {
+                    let _ = task_queue.add_task(body, description, timeout).await?;
+                }
+            }
+        }
     }
 
     Ok(())

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -36,7 +36,11 @@ async fn main() -> Result<()> {
             let task_queue = TaskQueue::new(ctx.clone(), &task_queue_args).await?;
 
             match task_queue_args.command {
-                TaskQueueCommand::AddTask { body, description, timeout} => {
+                TaskQueueCommand::AddTask {
+                    body,
+                    description,
+                    timeout,
+                } => {
                     let _ = task_queue.add_task(body, description, timeout).await?;
                 }
             }


### PR DESCRIPTION
_PR chain note: follows https://github.com/Lay3rLabs/avs-toolkit/pull/28_

Progress towards #2, with full functionality for "add a task".

Run like `cargo run task-queue add-task --body="{}" --description="hello"`

Payment amount is automatically derived by querying the contract (no need for arg)

The address is an optional argument, but will be taken from `LOCAL_TASK_QUEUE_ADDRESS` or `TEST_TASK_QUEUE_ADDRESS` env var (the CLI is already aware of .env, and the target environment is set in a top-level var)

This is also documented in the help: `cargo run task-queue --help`

A new PR will build in this to add the "view tasks" functionality