### PR TITLE
Easier WASI setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Compiled files and executables
 /target/
 artifacts/
+components/
 internal/
 
 # Code coverage

--- a/Cargo-component.lock
+++ b/Cargo-component.lock
@@ -8,4 +8,4 @@ name = "lay3r:avs"
 [[package.version]]
 requirement = "^0.3.0"
 version = "0.3.0"
-digest = "sha256:5ca2842d9fbc411429870dfe3b69cb6f787f7cea30598518849cf2edf03c7ce2"
+digest = "sha256:891753e8eab23c067ef8095359c28e4296a65faf416103e797f468dcb5f6b4a5"

--- a/scripts/build_wasi.sh
+++ b/scripts/build_wasi.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck >/dev/null && shellcheck "$0"
+
+# Compiles all WASI components, places the output in components dir
+
+
+OUTDIR="components"
+
+rm -rf "$OUTDIR"
+mkdir -p "$OUTDIR"
+
+rm -rf target/wasm32-wasip1/release/*.wasm "$OUTDIR"
+
+BASEDIR=$(pwd)
+for C in wasi/*/Cargo.toml; do
+  DIR=$(dirname "$C")
+  echo "Building WASI component in $DIR"
+  (
+    cd "$DIR";
+    cargo component build --release
+  )
+done
+
+cp target/wasm32-wasip1/release/*.wasm "$OUTDIR"
+
+ls -l "$OUTDIR"
+cd "$OUTDIR"
+sha256sum -- *.wasm | tee checksums.txt

--- a/scripts/collect_wasm.sh
+++ b/scripts/collect_wasm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Remoes old artifacts, compile new ones (not in docker, but faster), and places in artifacts dir with checksum
+# Removes old artifacts, compile new ones (not in docker, but faster), and places in artifacts dir with checksum
 
 # clear out old data and prepare space
 rm -rf artifacts

--- a/scripts/setup_wasi.sh
+++ b/scripts/setup_wasi.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck >/dev/null && shellcheck "$0"
+
+# The minimum Rust version we support
+MSRV="1.80.0"
+
+# install rustup if not present
+if ! which rustup > /dev/null; then 
+    echo "Installing Rustup tooling"
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+fi
+
+# ensure we have a recent-enough version of Rust
+V=$(cargo --version | cut -f2 -d' ')
+if [[ $V < $MSRV ]]; then
+    echo "Upgrading Rust to $MSRV"
+    rustup update stable
+fi
+
+# install the wasm32-wasi target
+echo "Adding WASI tooling..."
+rustup target add wasm32-wasip1
+cargo install cargo-component
+
+# setup wkg
+if [[ $OSTYPE == 'darwin'* ]]; then
+  WKG_DIR="$HOME/Library/Application Support/wasm-pkg"
+elif [[ $OSTYPE == 'linux'* ]]; then
+  WKG_DIR="$HOME/.config/wasm-pkg"
+else
+  echo "Unsupported OS: $OSTYPE"
+  exit 1
+fi
+WKG_FILE="$WKG_DIR/config.toml"
+
+if [ ! -f "$WKG_FILE" ]; then
+  echo "Creating wkg config file at $WKG_FILE"
+  mkdir -p "$WKG_DIR"
+  echo 'default_registry = "wa.dev"' > "$WKG_FILE"
+fi

--- a/wasi/square/README.md
+++ b/wasi/square/README.md
@@ -10,6 +10,8 @@ in simple test cases. You can find a [more complete example here](https://github
 
 ## Setup
 
+You can automatically run this setup via `./scripts/setup_wasi.sh` ([see source](../../scripts/setup_wasi.sh))
+
 This requires Rust 1.80+. Please ensure you have that installed via `rustup`
 before continuing.
 


### PR DESCRIPTION
Builds on https://github.com/Lay3rLabs/avs-toolkit/pull/26 but moves the setup and build instructions into easy scripts. Also assert the MSRV there, as a fellow (frontend) dev hit odd issues with a very old Rust version.

Setup seems to work.

The build script fails due to some issue in the code configuration I think. That is `./scripts/build_wasi.sh` as well as `cd wasi/square/ && cargo component build --release` provides:

```
error: component registry package `lay3r:avs` (v`0.3.0`) has digest `sha256:891753e8eab23c067ef8095359c28e4296a65faf416103e797f468dcb5f6b4a5` but the lock file specifies digest `sha256:5ca2842d9fbc411429870dfe3b69cb6f787f7cea30598518849cf2edf03c7ce2`
```