### PR TITLE
task queue view

### DIFF
--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -74,6 +74,9 @@ pub enum TaskQueueCommand {
         #[clap(short, long)]
         timeout: Option<u64>,
     },
+
+    /// View the task queue
+    ViewQueue,
 }
 
 #[derive(Copy, Clone, Debug, clap::ValueEnum)]

--- a/tools/cli/src/commands/mod.rs
+++ b/tools/cli/src/commands/mod.rs
@@ -1,2 +1,4 @@
 pub mod deploy;
+pub mod operator;
 pub mod task_queue;
+pub mod verifier;

--- a/tools/cli/src/commands/operator.rs
+++ b/tools/cli/src/commands/operator.rs
@@ -1,0 +1,45 @@
+use crate::context::AppContext;
+use anyhow::Result;
+use lavs_mock_operators::msg::{AllVotersResponse, QueryMsg};
+use layer_climb::prelude::*;
+
+pub struct OperatorQuerier {
+    pub ctx: AppContext,
+    pub contract_addr: Address,
+    pub querier: QueryClient,
+}
+
+impl OperatorQuerier {
+    pub async fn new(ctx: AppContext, contract_addr: Address) -> Result<Self> {
+        let querier = QueryClient::new(ctx.chain_config.as_ref().clone()).await?;
+        Ok(Self {
+            ctx,
+            contract_addr,
+            querier,
+        })
+    }
+
+    pub async fn all_operators(&self) -> Result<Vec<Operator>> {
+        let all_voters: AllVotersResponse = self
+            .querier
+            .contract_smart(&self.contract_addr, &QueryMsg::AllVoters {})
+            .await?;
+
+        all_voters
+            .voters
+            .into_iter()
+            .map(|v| {
+                let address = self.ctx.chain_config.parse_address(&v.address)?;
+                Ok(Operator {
+                    address,
+                    power: v.power.u128(),
+                })
+            })
+            .collect()
+    }
+}
+
+pub struct Operator {
+    pub address: Address,
+    pub power: u128,
+}

--- a/tools/cli/src/commands/verifier.rs
+++ b/tools/cli/src/commands/verifier.rs
@@ -1,0 +1,34 @@
+use crate::context::AppContext;
+use anyhow::Result;
+use lavs_verifier_simple::msg::{ConfigResponse, QueryMsg};
+use layer_climb::prelude::*;
+
+pub struct SimpleVerifierQuerier {
+    pub ctx: AppContext,
+    pub contract_addr: Address,
+    pub querier: QueryClient,
+}
+
+impl SimpleVerifierQuerier {
+    pub async fn new(ctx: AppContext, contract_addr: Address) -> Result<Self> {
+        let querier = QueryClient::new(ctx.chain_config.as_ref().clone()).await?;
+        Ok(Self {
+            ctx,
+            contract_addr,
+            querier,
+        })
+    }
+
+    pub async fn config(&self) -> Result<ConfigResponse> {
+        self.querier
+            .contract_smart(&self.contract_addr, &QueryMsg::Config {})
+            .await
+    }
+
+    pub async fn operator_addr(&self) -> Result<Address> {
+        let config = self.config().await?;
+        self.ctx
+            .chain_config
+            .parse_address(&config.operator_contract)
+    }
+}

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -43,6 +43,17 @@ async fn main() -> Result<()> {
                 } => {
                     let _ = task_queue.add_task(body, description, timeout).await?;
                 }
+                TaskQueueCommand::ViewQueue => {
+                    let mut buffer = Vec::new();
+
+                    let _ = task_queue
+                        .querier
+                        .task_queue_view()
+                        .await?
+                        .report(&mut buffer);
+
+                    tracing::info!("{}", String::from_utf8(buffer)?);
+                }
             }
         }
     }


### PR DESCRIPTION
builds on https://github.com/Lay3rLabs/avs-toolkit/pull/29

makes #2 feature-complete, but there's a remaining bug where it doesn't show expired tasks

@ethanfrey would you like me to add a "show all tasks with their status" query as part of this? or maybe separate PR that builds on this (there's a lot here)

Example run:

```bash
cargo run task-queue add-task --body="{\"content\": \"hello\"}" --description="best task ever"
cargo run task-queue add-task --body="{\"content\": \"world\"}" --description="best task ever"

cargo run task-queue view-queue
```

output:

```bash
 INFO Task Queue Configuration
Verifier: slay3r19rkr3cg0ru0327xpzsamd9c3rnqyldvtp38du6ec2dy59y98qz5qjghu60
Operator: slay3r1a3cqnpy4yv92nhl4vxreg7arq8vlzlwg0npm8hu6r027m3epagysx666vk

Operators:
  - slay3r1v340vw0q5qx49tj5hz85t64pekfelqt4cuxn4n: 1

Tasks:
  - Open Task: 9
    Expires: 1727708371
    Payload: {
  "content": "world"
}
  - Open Task: 8
    Expires: 1727708356
    Payload: {
  "content": "hello"
}
```