### PR TITLE
Fixes to various scripts

### DIFF
--- a/scripts/build_schemas.sh
+++ b/scripts/build_schemas.sh
@@ -2,6 +2,9 @@
 set -o errexit -o nounset -o pipefail
 command -v shellcheck >/dev/null && shellcheck "$0"
 
+# Enable recursive globbing
+shopt -s globstar
+
 rm -rf ./schemas
 mkdir -p ./schemas
 

--- a/scripts/build_wasi.sh
+++ b/scripts/build_wasi.sh
@@ -7,10 +7,8 @@ command -v shellcheck >/dev/null && shellcheck "$0"
 
 OUTDIR="components"
 
-rm -rf "$OUTDIR"
-mkdir -p "$OUTDIR"
-
 rm -rf target/wasm32-wasip1/release/*.wasm "$OUTDIR"
+mkdir -p "$OUTDIR"
 
 BASEDIR=$(pwd)
 for C in wasi/*/Cargo.toml; do

--- a/scripts/optimizer.sh
+++ b/scripts/optimizer.sh
@@ -18,6 +18,13 @@ A="linux/${M/x86_64/amd64}"
 S=${M#x86_64}
 S=${S:+-$S}
 
+# Ensure SSH agent is running and SSH_AUTH_SOCK is available
+if [ -z "$SSH_AUTH_SOCK" ]; then
+  echo "SSH_AUTH_SOCK is not set. Starting ssh-agent..."
+  eval $(ssh-agent)
+  echo "SSH agent started with SSH_AUTH_SOCK=$SSH_AUTH_SOCK"
+fi
+
 # We pass our ssh agent to the docker container, so it can pull dev dependencies properly
 if [[ $OSTYPE == 'darwin'* ]]; then
   $SUDO docker run --platform $A --rm -v "$(pwd)":/code \

--- a/scripts/optimizer.sh
+++ b/scripts/optimizer.sh
@@ -18,13 +18,6 @@ A="linux/${M/x86_64/amd64}"
 S=${M#x86_64}
 S=${S:+-$S}
 
-# Ensure SSH agent is running and SSH_AUTH_SOCK is available
-if [ -z "$SSH_AUTH_SOCK" ]; then
-  echo "SSH_AUTH_SOCK is not set. Starting ssh-agent..."
-  eval $(ssh-agent)
-  echo "SSH agent started with SSH_AUTH_SOCK=$SSH_AUTH_SOCK"
-fi
-
 # We pass our ssh agent to the docker container, so it can pull dev dependencies properly
 if [[ $OSTYPE == 'darwin'* ]]; then
   $SUDO docker run --platform $A --rm -v "$(pwd)":/code \
@@ -33,6 +26,13 @@ if [[ $OSTYPE == 'darwin'* ]]; then
   -v /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock -e SSH_AUTH_SOCK="/run/host-services/ssh-auth.sock" \
   $U/optimizer$S:$V
 else
+  # Ensure SSH agent is running and SSH_AUTH_SOCK is available
+  if [ -z "$SSH_AUTH_SOCK" ]; then
+    echo "SSH_AUTH_SOCK is not set. Starting ssh-agent..."
+    eval $(ssh-agent)
+    echo "SSH agent started with SSH_AUTH_SOCK=$SSH_AUTH_SOCK"
+  fi
+
   $SUDO docker run --platform $A --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \


### PR DESCRIPTION
## build_schemas.sh

Enable recursive globbing to correctly iterate through the contracts with Cargo.toml

Fixes this error result:
`Building schema for ./contracts/**/*
./scripts/build_schemas.sh: line 13: cd: ./contracts/**/*: No such file or directory`

## build_wasi.sh

Fix rm -rf command to happen only once before mkdir of $OUTDIR

`cp: target directory 'components': No such file or directory`

## optimizer.sh

Start ssh-agent to set $SSH_AUTH_SOCK before running optimizer

Fixes this error result:
`docker: invalid spec: :/ssh-agent: empty section between colons.`