### PR TITLE
Deploy more config

### DIFF
--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -65,7 +65,9 @@ pub enum DeployCommand {
         /// Artifacts path
         #[clap(short, long, default_value = "../../artifacts")]
         artifacts_path: PathBuf,
-        /// A list of operators. Voting power will be set with a ':' separator, otherwise it's `1`
+        /// A list of operators.
+        ///
+        /// Voting power will be set with a ':' separator, otherwise it's `1`
         #[clap(short, long, num_args(1..))]
         operators: Vec<String>,
         /// The default task timeout, in seconds
@@ -75,11 +77,16 @@ pub enum DeployCommand {
         #[clap(short, long, default_value_t = 70)]
         percentage: u32,
         /// The rules for allowed task requestors
+        ///
         /// Examples:
-        /// payment(100) - will require a payment of 100 gas tokens
-        /// payment(100, uslay) - will require a payment of 100 uslay (same as above)
-        /// fixed(slayaddresshere) - will require the caller be this specific address
-        /// deployer - will require the caller be the same as the deployer
+        ///
+        /// "payment(100)" - will require a payment of 100 gas tokens
+        ///
+        /// "payment(100, uslay)" - will require a payment of 100 uslay (same as above)
+        ///
+        /// "fixed(slayaddresshere)" - will require the caller be this specific address
+        ///
+        /// "deployer" - will require the caller be the same as the deployer
         #[clap(short, long, default_value_t = DeployTaskRequestor::default())]
         requestor: DeployTaskRequestor,
     },

--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -1,7 +1,9 @@
+use anyhow::{anyhow, Result};
 use clap::Parser;
 use clap::{Args, Subcommand};
 use layer_climb_cli::command::{ContractCommand, WalletCommand};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -63,6 +65,34 @@ pub enum DeployCommand {
         /// Artifacts path
         #[clap(short, long, default_value = "../../artifacts")]
         artifacts_path: PathBuf,
+        /// A list of operators. Voting power will be set with a ':' separator, otherwise it's `1`
+        #[clap(short, long, num_args(1..))]
+        operators: Vec<String>,
+        /// The default task timeout, in seconds
+        #[clap(short, long, default_value_t = 300)]
+        timeout: u64,
+        /// The required voting percentage for a task to be approved
+        #[clap(short, long, default_value_t = 70)]
+        percentage: u32,
+        /// The rules for allowed task requestors
+        /// Examples:
+        /// payment(100) - will require a payment of 100 gas tokens
+        /// payment(100, uslay) - will require a payment of 100 uslay (same as above)
+        /// fixed(slayaddresshere) - will require the caller be this specific address
+        /// deployer - will require the caller be the same as the deployer
+        #[clap(short, long, default_value_t = DeployTaskRequestor::default())]
+        requestor: DeployTaskRequestor,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub enum DeployTaskRequestor {
+    #[default]
+    Deployer,
+    Fixed(String),
+    Payment {
+        amount: u128,
+        denom: Option<String>,
     },
 }
 
@@ -162,4 +192,191 @@ impl From<LogLevel> for tracing::Level {
 pub enum TargetEnvironment {
     Local,
     Testnet,
+}
+
+/// Supporting impls needed for custom types
+impl FromStr for DeployTaskRequestor {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+
+        if s == "deployer" {
+            Ok(DeployTaskRequestor::Deployer)
+        } else if s.starts_with("payment(") && s.ends_with(')') {
+            let inner = &s[8..s.len() - 1]; // Extract content inside parentheses
+            let parts: Vec<&str> = inner.split(',').map(|s| s.trim()).collect();
+
+            match parts.len() {
+                1 => {
+                    let amount = parts[0]
+                        .parse::<u128>()
+                        .map_err(|_| anyhow!("invalid amount"))?;
+                    Ok(DeployTaskRequestor::Payment {
+                        amount,
+                        denom: None,
+                    })
+                }
+                2 => {
+                    let amount = parts[0]
+                        .parse::<u128>()
+                        .map_err(|_| anyhow!("invalid amount"))?;
+                    let denom = Some(parts[1].to_string());
+                    Ok(DeployTaskRequestor::Payment { amount, denom })
+                }
+                _ => Err(anyhow!("invalid format")),
+            }
+        } else if s.starts_with("fixed(") && s.ends_with(')') {
+            let inner = &s[6..s.len() - 1]; // Extract content inside parentheses
+            Ok(DeployTaskRequestor::Fixed(inner.trim().to_string()))
+        } else {
+            Err(anyhow!("unknown variant"))
+        }
+    }
+}
+
+impl std::fmt::Display for DeployTaskRequestor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeployTaskRequestor::Payment { amount, denom } => match denom {
+                Some(denom) => write!(f, "payment({}, {})", amount, denom),
+                None => write!(f, "payment({})", amount),
+            },
+            DeployTaskRequestor::Fixed(identifier) => {
+                write!(f, "fixed({})", identifier)
+            }
+            DeployTaskRequestor::Deployer => {
+                write!(f, "deployer")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_deployer() {
+        let input = "deployer";
+        let result = DeployTaskRequestor::from_str(input).unwrap();
+        assert_eq!(result, DeployTaskRequestor::Deployer);
+    }
+
+    #[test]
+    fn test_parse_payment_amount_only() {
+        let input = "payment(200)";
+        let result = DeployTaskRequestor::from_str(input).unwrap();
+        assert_eq!(
+            result,
+            DeployTaskRequestor::Payment {
+                amount: 200,
+                denom: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_payment_amount_and_denom() {
+        let input = "payment(300, USD)";
+        let result = DeployTaskRequestor::from_str(input).unwrap();
+        assert_eq!(
+            result,
+            DeployTaskRequestor::Payment {
+                amount: 300,
+                denom: Some("USD".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_payment_with_whitespace() {
+        let input = " payment( 400 ,  EUR ) ";
+        let result = DeployTaskRequestor::from_str(input).unwrap();
+        assert_eq!(
+            result,
+            DeployTaskRequestor::Payment {
+                amount: 400,
+                denom: Some("EUR".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_fixed() {
+        let input = "fixed(my_identifier)";
+        let result = DeployTaskRequestor::from_str(input).unwrap();
+        assert_eq!(
+            result,
+            DeployTaskRequestor::Fixed("my_identifier".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_fixed_with_whitespace() {
+        let input = " fixed( my_identifier ) ";
+        let result = DeployTaskRequestor::from_str(input).unwrap();
+        assert_eq!(
+            result,
+            DeployTaskRequestor::Fixed("my_identifier".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_invalid_variant() {
+        let input = "unknown(123)";
+        let result = DeployTaskRequestor::from_str(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_invalid_amount() {
+        let input = "payment(not_a_number)";
+        let result = DeployTaskRequestor::from_str(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_invalid_format_extra_fields() {
+        let input = "payment(100, USD, extra)";
+        let result = DeployTaskRequestor::from_str(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_invalid_format_no_parentheses() {
+        let input = "payment100, USD";
+        let result = DeployTaskRequestor::from_str(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_display_payment_without_denom() {
+        let requestor = DeployTaskRequestor::Payment {
+            amount: 100,
+            denom: None,
+        };
+        assert_eq!(format!("{}", requestor), "payment(100)");
+    }
+
+    #[test]
+    fn test_display_payment_with_denom() {
+        let requestor = DeployTaskRequestor::Payment {
+            amount: 200,
+            denom: Some("EUR".to_string()),
+        };
+        assert_eq!(format!("{}", requestor), "payment(200, EUR)");
+    }
+
+    #[test]
+    fn test_display_fixed() {
+        let requestor = DeployTaskRequestor::Fixed("identifier".to_string());
+        assert_eq!(format!("{}", requestor), "fixed(identifier)");
+    }
+
+    #[test]
+    fn test_display_deployer() {
+        let requestor = DeployTaskRequestor::Deployer;
+        assert_eq!(format!("{}", requestor), "deployer");
+    }
 }

--- a/tools/cli/src/commands/deploy.rs
+++ b/tools/cli/src/commands/deploy.rs
@@ -1,21 +1,82 @@
-use crate::context::AppContext;
+use crate::{args::DeployTaskRequestor, context::AppContext};
 use anyhow::{anyhow, bail, Result};
 use lavs_task_queue::msg::{Requestor, TimeoutInfo};
 use layer_climb::prelude::*;
 use std::path::PathBuf;
 use tokio::try_join;
 
-pub struct DeployContractAddrs {
-    pub operators: Address,
-    pub task_queue: Address,
-    pub verifier_simple: Address,
+#[derive(Debug)]
+pub struct DeployContractArgs {
+    artifacts_path: PathBuf,
+    operators: Vec<lavs_mock_operators::msg::InstantiateOperator>,
+    requestor: Requestor,
+    task_timeout: TimeoutInfo,
+    required_voting_percentage: u32,
+}
+
+impl DeployContractArgs {
+    pub async fn parse(
+        ctx: &AppContext,
+        artifacts_path: PathBuf,
+        task_timeout_seconds: u64,
+        required_voting_percentage: u32,
+        operators: Vec<String>,
+        requestor: DeployTaskRequestor,
+    ) -> Result<Self> {
+        let operators = operators
+            .into_iter()
+            .map(|s| {
+                let mut parts = s.split(':');
+                let addr = parts.next().unwrap().to_string();
+                let addr = ctx.chain_config()?.parse_address(&addr)?;
+                let voting_power = parts.next().unwrap_or("1").parse().unwrap();
+                anyhow::Ok(lavs_mock_operators::msg::InstantiateOperator::new(
+                    addr.to_string(),
+                    voting_power,
+                ))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let requestor = match requestor {
+            DeployTaskRequestor::Deployer => {
+                Requestor::Fixed(ctx.signing_client().await?.addr.to_string())
+            }
+            DeployTaskRequestor::Fixed(s) => {
+                Requestor::Fixed(ctx.chain_config()?.parse_address(&s)?.to_string())
+            }
+            DeployTaskRequestor::Payment { amount, denom } => {
+                Requestor::OpenPayment(cosmwasm_std::coin(
+                    amount,
+                    denom.unwrap_or(ctx.chain_config()?.gas_denom.clone()),
+                ))
+            }
+        };
+
+        let task_timeout = TimeoutInfo::new(task_timeout_seconds);
+
+        Ok(Self {
+            artifacts_path,
+            operators,
+            requestor,
+            task_timeout,
+            required_voting_percentage,
+        })
+    }
 }
 
 pub async fn deploy_contracts(
     ctx: AppContext,
-    artifacts_path: PathBuf,
+    args: DeployContractArgs,
 ) -> Result<DeployContractAddrs> {
-    tracing::debug!("Uploading contracts from {:?}", artifacts_path);
+    tracing::debug!("Deploying contracts with args: {:#?}", args);
+
+    let DeployContractArgs {
+        artifacts_path,
+        operators,
+        requestor,
+        task_timeout,
+        required_voting_percentage,
+    } = args;
 
     let wasm_files = WasmFiles::read(artifacts_path.clone()).await?;
 
@@ -34,12 +95,7 @@ pub async fn deploy_contracts(
             client.addr.clone(),
             operators_code_id,
             "Mock Operators",
-            &lavs_mock_operators::msg::InstantiateMsg {
-                operators: vec![lavs_mock_operators::msg::InstantiateOperator::new(
-                    client.addr.to_string(),
-                    1,
-                )],
-            },
+            &lavs_mock_operators::msg::InstantiateMsg { operators },
             vec![],
             None,
         )
@@ -55,7 +111,7 @@ pub async fn deploy_contracts(
             "Verifier Simple",
             &lavs_verifier_simple::msg::InstantiateMsg {
                 operator_contract: operators_addr.to_string(),
-                required_percentage: 1,
+                required_percentage: required_voting_percentage,
             },
             vec![],
             None,
@@ -71,11 +127,8 @@ pub async fn deploy_contracts(
             task_queue_code_id,
             "Task Queue",
             &lavs_task_queue::msg::InstantiateMsg {
-                requestor: Requestor::OpenPayment(cosmwasm_std::coin(
-                    100,
-                    &client.querier.chain_config.gas_denom,
-                )),
-                timeout: TimeoutInfo::new(100),
+                requestor,
+                timeout: task_timeout,
                 verifier: verifier_addr.to_string(),
             },
             vec![],
@@ -91,6 +144,12 @@ pub async fn deploy_contracts(
         task_queue: task_queue_addr,
         verifier_simple: verifier_addr,
     })
+}
+
+pub struct DeployContractAddrs {
+    pub operators: Address,
+    pub task_queue: Address,
+    pub verifier_simple: Address,
 }
 
 struct WasmFiles {


### PR DESCRIPTION
_PR chain note: builds off https://github.com/Lay3rLabs/avs-toolkit/pull/38_

finally closes #2

adds all the config options to deploy command.

Output from `cargo run deploy contracts --help`

```
Deploy all the contracts needed for the system to work

Usage: avs-toolkit-cli deploy contracts [OPTIONS]

Options:
  -a, --artifacts-path <ARTIFACTS_PATH>
          Artifacts path

          [default: ../../artifacts]

  -o, --operators <OPERATORS>...
          A list of operators.

          Voting power will be set with a ':' separator, otherwise it's `1`

  -t, --timeout <TIMEOUT>
          The default task timeout, in seconds

          [default: 300]

  -p, --percentage <PERCENTAGE>
          The required voting percentage for a task to be approved

          [default: 70]

  -r, --requestor <REQUESTOR>
          The rules for allowed task requestors

          Examples:

          "payment(100)" - will require a payment of 100 gas tokens

          "payment(100, uslay)" - will require a payment of 100 uslay (same as above)

          "fixed(slayaddresshere)" - will require the caller be this specific address

          "deployer" - will require the caller be the same as the deployer

          [default: deployer]

  -h, --help
          Print help (see a summary with '-h')
```