### PR TITLE
Fix task msgs schemas

### DIFF
--- a/packages/apis/src/tasks.rs
+++ b/packages/apis/src/tasks.rs
@@ -48,12 +48,11 @@ impl TimeoutInfo {
 }
 
 #[cw_serde]
+#[serde(untagged)]
 pub enum ExecuteMsg {
     /// Complete and any other public APIs in the interface
-    #[serde(untagged)]
     Api(TaskExecuteMsg),
     /// The messages unique to this contract implementation
-    #[serde(untagged)]
     Custom(CustomExecuteMsg),
 }
 
@@ -92,12 +91,11 @@ impl From<TaskExecuteMsg> for ExecuteMsg {
 #[cw_serde]
 #[derive(QueryResponses)]
 #[query_responses(nested)]
+#[serde(untagged)]
 pub enum QueryMsg {
     /// Complete and any other public APIs in the interface
-    #[serde(untagged)]
     Api(TaskQueryMsg),
     /// The messages unique to this implementation
-    #[serde(untagged)]
     Custom(CustomQueryMsg),
 }
 


### PR DESCRIPTION
Moves the #[serde(untagged)] to the top level msg. This removes the API and Custom tags to produce a flat execute/query schema as intended.

https://lay3r.slack.com/archives/C07LTKJMP0A/p1727862369579609?thread_ts=1727862364.833559&cid=C07LTKJMP0A