### PR TITLE
better operator args

### DIFF
--- a/tools/cli/config.json
+++ b/tools/cli/config.json
@@ -19,5 +19,8 @@
     },
     "faucet": {
         "mnemonic": "economy stock theory fatal elder harbor betray wasp final emotion task crumble siren bottom lizard educate guess current outdoor pair theory focus wife stone"
+    },
+    "wasmatic": {
+        "endpoint": "http://localhost:8081"
     }
   }

--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -68,6 +68,10 @@ pub enum DeployCommand {
         /// A list of operators.
         ///
         /// Voting power will be set with a ':' separator, otherwise it's `1`
+        ///
+        /// At least one operator must be set
+        ///
+        /// Tip: "wasmatic" is a special operator that will be set with the wasmatic address
         #[clap(short, long, num_args(1..))]
         operators: Vec<String>,
         /// The default task timeout, in seconds

--- a/tools/cli/src/commands/deploy.rs
+++ b/tools/cli/src/commands/deploy.rs
@@ -23,12 +23,20 @@ impl DeployContractArgs {
         operators: Vec<String>,
         requestor: DeployTaskRequestor,
     ) -> Result<Self> {
+        if operators.is_empty() {
+            bail!("At least one operator must be specified");
+        }
+
         let operators = operators
             .into_iter()
             .map(|s| {
                 let mut parts = s.split(':');
                 let addr = parts.next().unwrap().to_string();
-                let addr = ctx.chain_config()?.parse_address(&addr)?;
+                let addr = match addr.as_str() {
+                    "wasmatic" => ctx.config.wasmatic.address.clone(),
+                    _ => ctx.chain_config()?.parse_address(&addr)?,
+                };
+
                 let voting_power = parts.next().unwrap_or("1").parse().unwrap();
                 anyhow::Ok(lavs_mock_operators::msg::InstantiateOperator::new(
                     addr.to_string(),

--- a/tools/cli/src/config.rs
+++ b/tools/cli/src/config.rs
@@ -2,18 +2,81 @@ use anyhow::{Context, Result};
 use layer_climb::prelude::*;
 use serde::{Deserialize, Serialize};
 
+// This is the on-disk config
+// it's not the final config that gets filled in asynchrnously
+#[derive(Debug, Deserialize, Serialize)]
+pub struct OnDiskConfig {
+    pub chains: ChainConfigs,
+    pub faucet: FaucetConfig,
+    pub wasmatic: OnDiskWasmaticConfig,
+}
+#[derive(Debug, Deserialize, Serialize)]
+pub struct OnDiskWasmaticConfig {
+    pub endpoint: String,
+}
+
+// This is the actual, final config that gets used throughout the app
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     pub chains: ChainConfigs,
     pub faucet: FaucetConfig,
+    pub wasmatic: WasmaticConfig,
 }
 
 impl Config {
     // Load the config from the file
     // but in theory this could be from chain, http endpoint, avs, etc.
+    // internally, it does additional loads as needed (e.g. from wasmatic endpoint)
     pub async fn load() -> Result<Self> {
-        serde_json::from_str(include_str!("../config.json")).context("Failed to parse config")
+        let config: OnDiskConfig = serde_json::from_str(include_str!("../config.json"))
+            .context("Failed to parse config")?;
+
+        // SANITY CHECK
+        // make sure every chain has the same address kind
+
+        let address_kind = match (&config.chains.local, &config.chains.testnet) {
+            (Some(local), Some(testnet)) => {
+                if local.address_kind != testnet.address_kind {
+                    return Err(anyhow::anyhow!(
+                        "Local and testnet chains must have the same address kind"
+                    ));
+                }
+
+                &local.address_kind
+            }
+            (Some(local), None) => &local.address_kind,
+            (None, Some(testnet)) => &testnet.address_kind,
+            (None, None) => return Err(anyhow::anyhow!("At least one chain must be configured")),
+        };
+
+        let wasmatic_address = load_wasmatic_address(&config.wasmatic.endpoint).await?;
+
+        Ok(Config {
+            wasmatic: WasmaticConfig {
+                endpoint: config.wasmatic.endpoint,
+                address: match &address_kind {
+                    // TODO- this should be a method on AddrKind
+                    AddrKind::Cosmos { prefix } => {
+                        Address::new_cosmos_string(&wasmatic_address, Some(prefix))?
+                    }
+                    AddrKind::Eth => Address::new_eth_string(&wasmatic_address)?,
+                },
+            },
+            chains: config.chains,
+            faucet: config.faucet,
+        })
     }
+}
+
+async fn load_wasmatic_address(_endpoint: &str) -> Result<String> {
+    // TODO: Load from endpoint
+    Ok("layer1qyfn9l7w78kxcerwwwc6dpad305dulhk9jks0r".to_string())
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WasmaticConfig {
+    pub endpoint: String,
+    pub address: Address,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Changes:

1. requires that there be at least one operator
2. if the address is "wasmatic", uses the wasmatic address
3. plumbing setup for loading that wasmatic asynchronously, as part of initial config

Does _NOT_ fix the auth error, will update on Slack, but I think this PR is a step forward, so not opening as draft (unfortunately I have to run now - don't have time to fix completely)