### PR TITLE
Point to layer-p.net as testnet

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -31,16 +31,14 @@ In this directory:
 Local
 
 ```bash
-cargo run -- deploy contracts --operators wasmatic
+cargo run -- --target=local deploy contracts --operators wasmatic
 ```
 
 Testnet
 
 ```bash
-cargo run -- --target-env=testnet deploy contracts --operators wasmatic
+cargo run -- --target=testnet deploy contracts --operators wasmatic
 ```
-
-If you want to see an output at the end with the different contract's addresses, make sure to run with --
 
 Store the task queue for future use, based on the output:
 
@@ -61,3 +59,5 @@ cargo run -- task-queue add-task --body '{"x": 9}' --description 'Square nine'
 
 cargo run -- task-queue view-queue
 ```
+
+If you want to see an output at the end with the different contract's addresses, make sure to run with `--address=<ADDRESS>`

--- a/tools/cli/config.json
+++ b/tools/cli/config.json
@@ -21,6 +21,7 @@
         "mnemonic": "economy stock theory fatal elder harbor betray wasp final emotion task crumble siren bottom lizard educate guess current outdoor pair theory focus wife stone"
     },
     "wasmatic": {
-        "endpoint": "https://op1.layer-p.net"
+        "endpoint": "http://localhost:8081",
+        "//endpoint": "https://op1.layer-p.net"
     }
 }

--- a/tools/cli/config.json
+++ b/tools/cli/config.json
@@ -9,11 +9,11 @@
             "address_kind": {"cosmos":{"prefix":"layer"}}
         },
         "testnet": {
-            "chain_id": "slay3r-dev",
-            "rpc_endpoint": "https://lcd.dev-cav3.net",
-            "grpc_endpoint": "https://grpc.dev-cav3.net:443",
+            "chain_id": "layer-permissionless-3",
+            "rpc_endpoint": "https://rpc.layer-p.net",
+            "grpc_endpoint": "https://grpc.layer-p.net:443",
             "gas_amount": "0.025",
-            "gas_denom": "uslay",
+            "gas_denom": "uperm",
             "address_kind": {"cosmos":{"prefix":"layer"}}
         }
     },
@@ -21,6 +21,6 @@
         "mnemonic": "economy stock theory fatal elder harbor betray wasp final emotion task crumble siren bottom lizard educate guess current outdoor pair theory focus wife stone"
     },
     "wasmatic": {
-        "endpoint": "http://localhost:8081"
+        "endpoint": "https://op1.layer-p.net"
     }
-  }
+}

--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -9,8 +9,8 @@ use std::str::FromStr;
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 pub struct CliArgs {
-    #[arg(long, value_enum, default_value_t = TargetEnvironment::Local)]
-    pub env: TargetEnvironment,
+    #[arg(long, value_enum, default_value_t = TargetEnvironment::Testnet)]
+    pub target: TargetEnvironment,
 
     /// Set the logging level
     #[arg(long, value_enum, default_value_t = LogLevel::Info)]

--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -9,7 +9,8 @@ use std::str::FromStr;
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 pub struct CliArgs {
-    #[arg(long, value_enum, default_value_t = TargetEnvironment::Testnet)]
+    // #[arg(long, value_enum, default_value_t = TargetEnvironment::Testnet)]
+    #[arg(long, value_enum, default_value_t = TargetEnvironment::Local)]
     pub target: TargetEnvironment,
 
     /// Set the logging level

--- a/tools/cli/src/commands/task_queue.rs
+++ b/tools/cli/src/commands/task_queue.rs
@@ -27,7 +27,7 @@ impl TaskQueue {
     pub async fn new(ctx: AppContext, task_queue_args: &TaskQueueArgs) -> Result<Self> {
         let addr_string = match task_queue_args.address.clone() {
             Some(x) => x,
-            None => match ctx.args.env {
+            None => match ctx.args.target {
                 TargetEnvironment::Local => std::env::var("LOCAL_TASK_QUEUE_ADDRESS")
                     .context("LOCAL_TASK_QUEUE_ADDRESS not found")?,
                 TargetEnvironment::Testnet => std::env::var("TEST_TASK_QUEUE_ADDRESS")

--- a/tools/cli/src/config.rs
+++ b/tools/cli/src/config.rs
@@ -84,7 +84,7 @@ async fn load_wasmatic_address(endpoint: &str) -> Result<String> {
         .send()
         .await?;
     let info: GetInfo = response.json().await?;
-    let op = info.operators.get(0).context("No operators found")?;
+    let op = info.operators.first().context("No operators found")?;
 
     Ok(op.to_string())
 }

--- a/tools/cli/src/config.rs
+++ b/tools/cli/src/config.rs
@@ -68,9 +68,25 @@ impl Config {
     }
 }
 
-async fn load_wasmatic_address(_endpoint: &str) -> Result<String> {
-    // TODO: Load from endpoint
-    Ok("layer1qyfn9l7w78kxcerwwwc6dpad305dulhk9jks0r".to_string())
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetInfo {
+    pub operators: Vec<String>,
+}
+
+async fn load_wasmatic_address(endpoint: &str) -> Result<String> {
+    let client = reqwest::Client::new();
+
+    // Load from info endpoint
+    let response = client
+        .get(format!("{}/info", endpoint))
+        .header("Content-Type", "application/json")
+        .send()
+        .await?;
+    let info: GetInfo = response.json().await?;
+    let op = info.operators.get(0).context("No operators found")?;
+
+    Ok(op.to_string())
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/tools/cli/src/context.rs
+++ b/tools/cli/src/context.rs
@@ -30,19 +30,19 @@ impl AppContext {
     }
 
     pub fn chain_config(&self) -> Result<&ChainConfig> {
-        match self.args.env {
+        match self.args.target {
             TargetEnvironment::Local => &self.config.chains.local,
             TargetEnvironment::Testnet => &self.config.chains.testnet,
         }
         .as_ref()
         .context(format!(
             "Chain config for environment {:?} not found",
-            self.args.env
+            self.args.target
         ))
     }
 
     pub fn client_mnemonic(&self) -> Result<String> {
-        let mnemonic_var = match self.args.env {
+        let mnemonic_var = match self.args.target {
             TargetEnvironment::Local => "LOCAL_MNEMONIC",
             TargetEnvironment::Testnet => "TEST_MNEMONIC",
         };


### PR DESCRIPTION
This updates the default testnet config to point to layer-p.net, which is the permissionless 3 hackathon testnet.

It also auto-loads the operator address from wasmatic `/info` endpoint.

I didn't make testnet the default, as I realized we cannot properly switch yet.
That needs https://github.com/Lay3rLabs/avs-toolkit/issues/59