### PR TITLE
Adjustments to ChainConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "layer-climb"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=d8f3996fb35fa06c5dd56390570094d8158a442f#d8f3996fb35fa06c5dd56390570094d8158a442f"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d1c497fab5d9273565b0b689b83bdd159ad2a441#d1c497fab5d9273565b0b689b83bdd159ad2a441"
 dependencies = [
  "layer-climb-address",
  "layer-climb-config",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-address"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=d8f3996fb35fa06c5dd56390570094d8158a442f#d8f3996fb35fa06c5dd56390570094d8158a442f"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d1c497fab5d9273565b0b689b83bdd159ad2a441#d1c497fab5d9273565b0b689b83bdd159ad2a441"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-cli"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=d8f3996fb35fa06c5dd56390570094d8158a442f#d8f3996fb35fa06c5dd56390570094d8158a442f"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d1c497fab5d9273565b0b689b83bdd159ad2a441#d1c497fab5d9273565b0b689b83bdd159ad2a441"
 dependencies = [
  "anyhow",
  "bip39",
@@ -2634,7 +2634,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-config"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=d8f3996fb35fa06c5dd56390570094d8158a442f#d8f3996fb35fa06c5dd56390570094d8158a442f"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d1c497fab5d9273565b0b689b83bdd159ad2a441#d1c497fab5d9273565b0b689b83bdd159ad2a441"
 dependencies = [
  "anyhow",
  "serde",
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-core"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=d8f3996fb35fa06c5dd56390570094d8158a442f#d8f3996fb35fa06c5dd56390570094d8158a442f"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d1c497fab5d9273565b0b689b83bdd159ad2a441#d1c497fab5d9273565b0b689b83bdd159ad2a441"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-proto"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=d8f3996fb35fa06c5dd56390570094d8158a442f#d8f3996fb35fa06c5dd56390570094d8158a442f"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d1c497fab5d9273565b0b689b83bdd159ad2a441#d1c497fab5d9273565b0b689b83bdd159ad2a441"
 dependencies = [
  "anyhow",
  "cosmos-sdk-proto 0.25.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "layer-climb"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=d1c497fab5d9273565b0b689b83bdd159ad2a441#d1c497fab5d9273565b0b689b83bdd159ad2a441"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=5436381a7c35344325bd27ea32261ebcd2d76baa#5436381a7c35344325bd27ea32261ebcd2d76baa"
 dependencies = [
  "layer-climb-address",
  "layer-climb-config",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-address"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=d1c497fab5d9273565b0b689b83bdd159ad2a441#d1c497fab5d9273565b0b689b83bdd159ad2a441"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=5436381a7c35344325bd27ea32261ebcd2d76baa#5436381a7c35344325bd27ea32261ebcd2d76baa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-cli"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=d1c497fab5d9273565b0b689b83bdd159ad2a441#d1c497fab5d9273565b0b689b83bdd159ad2a441"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=5436381a7c35344325bd27ea32261ebcd2d76baa#5436381a7c35344325bd27ea32261ebcd2d76baa"
 dependencies = [
  "anyhow",
  "bip39",
@@ -2634,7 +2634,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-config"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=d1c497fab5d9273565b0b689b83bdd159ad2a441#d1c497fab5d9273565b0b689b83bdd159ad2a441"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=5436381a7c35344325bd27ea32261ebcd2d76baa#5436381a7c35344325bd27ea32261ebcd2d76baa"
 dependencies = [
  "anyhow",
  "serde",
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-core"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=d1c497fab5d9273565b0b689b83bdd159ad2a441#d1c497fab5d9273565b0b689b83bdd159ad2a441"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=5436381a7c35344325bd27ea32261ebcd2d76baa#5436381a7c35344325bd27ea32261ebcd2d76baa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-proto"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=d1c497fab5d9273565b0b689b83bdd159ad2a441#d1c497fab5d9273565b0b689b83bdd159ad2a441"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=5436381a7c35344325bd27ea32261ebcd2d76baa#5436381a7c35344325bd27ea32261ebcd2d76baa"
 dependencies = [
  "anyhow",
  "cosmos-sdk-proto 0.25.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is-terminal"
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "layer-climb"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=ade504edeb54ce5c08a8c3a089d39db83fd9757c#ade504edeb54ce5c08a8c3a089d39db83fd9757c"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d8f3996fb35fa06c5dd56390570094d8158a442f#d8f3996fb35fa06c5dd56390570094d8158a442f"
 dependencies = [
  "layer-climb-address",
  "layer-climb-config",
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-address"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=ade504edeb54ce5c08a8c3a089d39db83fd9757c#ade504edeb54ce5c08a8c3a089d39db83fd9757c"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d8f3996fb35fa06c5dd56390570094d8158a442f#d8f3996fb35fa06c5dd56390570094d8158a442f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-cli"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=ade504edeb54ce5c08a8c3a089d39db83fd9757c#ade504edeb54ce5c08a8c3a089d39db83fd9757c"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d8f3996fb35fa06c5dd56390570094d8158a442f#d8f3996fb35fa06c5dd56390570094d8158a442f"
 dependencies = [
  "anyhow",
  "bip39",
@@ -2634,7 +2634,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-config"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=ade504edeb54ce5c08a8c3a089d39db83fd9757c#ade504edeb54ce5c08a8c3a089d39db83fd9757c"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d8f3996fb35fa06c5dd56390570094d8158a442f#d8f3996fb35fa06c5dd56390570094d8158a442f"
 dependencies = [
  "anyhow",
  "serde",
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-core"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=ade504edeb54ce5c08a8c3a089d39db83fd9757c#ade504edeb54ce5c08a8c3a089d39db83fd9757c"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d8f3996fb35fa06c5dd56390570094d8158a442f#d8f3996fb35fa06c5dd56390570094d8158a442f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "layer-climb-proto"
 version = "0.0.0"
-source = "git+https://github.com/Lay3rLabs/climb.git?rev=ade504edeb54ce5c08a8c3a089d39db83fd9757c#ade504edeb54ce5c08a8c3a089d39db83fd9757c"
+source = "git+https://github.com/Lay3rLabs/climb.git?rev=d8f3996fb35fa06c5dd56390570094d8158a442f#d8f3996fb35fa06c5dd56390570094d8158a442f"
 dependencies = [
  "anyhow",
  "cosmos-sdk-proto 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ dotenvy = {version = "0.15.7", features = ["cli"]}
 tracing-subscriber = "0.3.18"
 bip39 = "2.0.0"
 rand = "0.8"
-layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "ade504edeb54ce5c08a8c3a089d39db83fd9757c"}
-layer-climb-cli = { git = "https://github.com/Lay3rLabs/climb.git", rev = "ade504edeb54ce5c08a8c3a089d39db83fd9757c"}
+layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "d8f3996fb35fa06c5dd56390570094d8158a442f" }
+layer-climb-cli = { git = "https://github.com/Lay3rLabs/climb.git", rev = "d8f3996fb35fa06c5dd56390570094d8158a442f" }
 reqwest = { version = "0.11", features = ["json", "rustls-tls", "stream", "blocking", "multipart"] }
 sha2 = "0.10"
 # purposefully left in for now to make debugging easier, will remove eventually:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ dotenvy = {version = "0.15.7", features = ["cli"]}
 tracing-subscriber = "0.3.18"
 bip39 = "2.0.0"
 rand = "0.8"
-layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "d8f3996fb35fa06c5dd56390570094d8158a442f" }
-layer-climb-cli = { git = "https://github.com/Lay3rLabs/climb.git", rev = "d8f3996fb35fa06c5dd56390570094d8158a442f" }
+layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "d1c497fab5d9273565b0b689b83bdd159ad2a441" }
+layer-climb-cli = { git = "https://github.com/Lay3rLabs/climb.git", rev = "d1c497fab5d9273565b0b689b83bdd159ad2a441" }
 reqwest = { version = "0.11", features = ["json", "rustls-tls", "stream", "blocking", "multipart"] }
 sha2 = "0.10"
 # purposefully left in for now to make debugging easier, will remove eventually:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ dotenvy = {version = "0.15.7", features = ["cli"]}
 tracing-subscriber = "0.3.18"
 bip39 = "2.0.0"
 rand = "0.8"
-layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "d1c497fab5d9273565b0b689b83bdd159ad2a441" }
-layer-climb-cli = { git = "https://github.com/Lay3rLabs/climb.git", rev = "d1c497fab5d9273565b0b689b83bdd159ad2a441" }
+layer-climb = { git = "https://github.com/Lay3rLabs/climb.git", rev = "5436381a7c35344325bd27ea32261ebcd2d76baa" }
+layer-climb-cli = { git = "https://github.com/Lay3rLabs/climb.git", rev = "5436381a7c35344325bd27ea32261ebcd2d76baa" }
 reqwest = { version = "0.11", features = ["json", "rustls-tls", "stream", "blocking", "multipart"] }
 sha2 = "0.10"
 # purposefully left in for now to make debugging easier, will remove eventually:

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,0 +1,100 @@
+# Demo with Testnet
+
+This shows how to deploy an AVS on the permissionless and setup stuff
+
+## Check Testnet Connectivity
+
+```bash
+# Ensure the chain is up
+curl https://rpc.layer-p.net/status
+
+# see blocks are being made.. run a few times
+curl https://rpc.layer-p.net/status | jq .result.sync_info
+
+# ensure wasmatic opertators are set up with different addresses
+curl https://op1.layer-p.net/info | jq -r .operators[0]
+curl https://op2.layer-p.net/info | jq -r .operators[0]
+curl https://op3.layer-p.net/info | jq -r .operators[0]
+```
+
+## Deploy AVS stuff
+
+Go into `tools/cli` dir to run all the other commands.
+More info available on the [README there](./tools/cli/README.md).
+
+### Set Up Wallet
+
+```bash
+M=$(cargo run wallet create | tail -1 | cut -c16-)
+echo "TEST_MNEMONIC=\"$M\"" > .env
+# this should have a nice 24 word phrase
+cat .env
+
+cargo run faucet tap
+cargo run wallet show
+```
+
+### Deploy Contracts
+
+```bash
+# rebuild the contracts locally
+(cd ../.. && ./scripts/optimizer.sh)
+
+# deploy them
+cargo run deploy contracts --operators wasmatic
+
+# Copy the line that says "export TEST_TASK_QUEUE_ADDRESS" and paste it in your shell
+
+cargo run task-queue view-queue
+```
+
+### Deploy WASI component
+
+```bash
+# rebuild the component
+(cd ../.. && ./scripts/build_wasi.sh)
+
+# Testable is optional if you want to try the next step
+# Do not use for production deployments
+cargo run -- wasmatic deploy --name YOUR_NAME_HERE \
+    --wasm-source ../../components/cavs_square.wasm  \
+    --testable \
+    --task $TEST_TASK_QUEUE_ADDRESS
+```
+
+## Test a Component
+
+This can only be done if `--testable` was provided above
+
+```bash
+cargo run -- wasmatic test --name YOUR_NAME_HERE --input '{"x": 32}'
+```
+
+It will parse the input as if you pushed it to the task queue and return
+the result (or error) to the caller. Nothing is written on chain.
+
+Note: if you change state when being triggered, this will break the AVS
+consensus mechanism (different results for different operators), and thus
+should not be used in production.
+
+## Trigger Task
+
+```bash
+cargo run task-queue view-queue
+
+cargo run task-queue add-task -b '{"x": 12}' -d 'test 1'
+
+# wait a few secords, or until the log output shows it is executed
+cargo run task-queue view-queue
+```
+
+## Clean Up Application (Optional)
+
+There is a global namespace for these applications, so you might get a conflict above
+if you paste in YOUR_NAME_HERE after someone else did the same, without replacing
+it with your favorite name. To make life easier for yourself (and others) later,
+if you are not using the instance, you can remove it later.
+
+```bash
+cargo run -- wasmatic remove --name YOUR_NAME_HERE
+```

--- a/tools/cli/config.json
+++ b/tools/cli/config.json
@@ -1,6 +1,6 @@
 {
-    "chains": {
-        "local": {
+    "local": {
+        "chain": {
             "chain_id": "slay3r-local",
             "rpc_endpoint": "http://localhost:26657",
             "grpc_endpoint": "http://localhost:9090",
@@ -10,15 +10,17 @@
                 "cosmos": {
                     "prefix": "layer"
                 }
-            },
-            "faucet": {
-                "mnemonic": "economy stock theory fatal elder harbor betray wasp final emotion task crumble siren bottom lizard educate guess current outdoor pair theory focus wife stone"
-            },
-            "wasmatic": {
-                "endpoint": "http://localhost:8081"
             }
         },
-        "testnet": {
+        "faucet": {
+            "mnemonic": "economy stock theory fatal elder harbor betray wasp final emotion task crumble siren bottom lizard educate guess current outdoor pair theory focus wife stone"
+        },
+        "wasmatic": {
+            "endpoint": "http://localhost:8081"
+        }
+    },
+    "testnet": {
+        "chain": {
             "chain_id": "layer-permissionless-3",
             "rpc_endpoint": "https://rpc.layer-p.net",
             "grpc_endpoint": "https://grpc.layer-p.net:443",
@@ -28,13 +30,13 @@
                 "cosmos": {
                     "prefix": "layer"
                 }
-            },
-            "faucet": {
-                "mnemonic": "economy stock theory fatal elder harbor betray wasp final emotion task crumble siren bottom lizard educate guess current outdoor pair theory focus wife stone"
-            },
-            "wasmatic": {
-                "endpoint": "http://op.layer-p.net"
-            }
+            }    
+        },
+        "faucet": {
+            "mnemonic": "feel slide lunch main narrow illness goose foster income exotic trim brief install million slab myth marine uncover club eye evolve edit angle decrease"
+        },
+        "wasmatic": {
+            "endpoint": "http://op.layer-p.net"
         }
     }
 }

--- a/tools/cli/config.json
+++ b/tools/cli/config.json
@@ -36,7 +36,7 @@
             "mnemonic": "feel slide lunch main narrow illness goose foster income exotic trim brief install million slab myth marine uncover club eye evolve edit angle decrease"
         },
         "wasmatic": {
-            "endpoint": "http://op.layer-p.net"
+            "endpoint": "http://op1.layer-p.net"
         }
     }
 }

--- a/tools/cli/config.json
+++ b/tools/cli/config.json
@@ -6,7 +6,17 @@
             "grpc_endpoint": "http://localhost:9090",
             "gas_amount": "0.025",
             "gas_denom": "uslay",
-            "address_kind": {"cosmos":{"prefix":"layer"}}
+            "address_kind": {
+                "cosmos": {
+                    "prefix": "layer"
+                }
+            },
+            "faucet": {
+                "mnemonic": "economy stock theory fatal elder harbor betray wasp final emotion task crumble siren bottom lizard educate guess current outdoor pair theory focus wife stone"
+            },
+            "wasmatic": {
+                "endpoint": "http://localhost:8081"
+            }
         },
         "testnet": {
             "chain_id": "layer-permissionless-3",
@@ -14,14 +24,17 @@
             "grpc_endpoint": "https://grpc.layer-p.net:443",
             "gas_amount": "0.025",
             "gas_denom": "uperm",
-            "address_kind": {"cosmos":{"prefix":"layer"}}
+            "address_kind": {
+                "cosmos": {
+                    "prefix": "layer"
+                }
+            },
+            "faucet": {
+                "mnemonic": "economy stock theory fatal elder harbor betray wasp final emotion task crumble siren bottom lizard educate guess current outdoor pair theory focus wife stone"
+            },
+            "wasmatic": {
+                "endpoint": "http://op.layer-p.net"
+            }
         }
-    },
-    "faucet": {
-        "mnemonic": "economy stock theory fatal elder harbor betray wasp final emotion task crumble siren bottom lizard educate guess current outdoor pair theory focus wife stone"
-    },
-    "wasmatic": {
-        "endpoint": "http://localhost:8081",
-        "//endpoint": "https://op1.layer-p.net"
     }
 }

--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -190,9 +190,6 @@ impl FaucetCommand {
 
 #[derive(Clone, Args)]
 pub struct WasmaticArgs {
-    #[clap(long, default_value = "http://0.0.0.0:8081")]
-    pub address: String,
-
     #[command(subcommand)]
     pub command: WasmaticCommand,
 }

--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -9,8 +9,8 @@ use std::str::FromStr;
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 pub struct CliArgs {
-    // #[arg(long, value_enum, default_value_t = TargetEnvironment::Testnet)]
-    #[arg(long, value_enum, default_value_t = TargetEnvironment::Local)]
+    #[arg(long, value_enum, default_value_t = TargetEnvironment::Testnet)]
+    // #[arg(long, value_enum, default_value_t = TargetEnvironment::Local)]
     pub target: TargetEnvironment,
 
     /// Set the logging level

--- a/tools/cli/src/commands/deploy.rs
+++ b/tools/cli/src/commands/deploy.rs
@@ -33,9 +33,10 @@ impl DeployContractArgs {
             let addr_str = parts.next().unwrap().to_string();
             let addr = match addr_str.as_str() {
                 "wasmatic" => {
-                    let chain_config = ctx.chain_config()?;
+                    let chain_info = ctx.chain_info()?;
+                    let chain_config = &chain_info.chain;
                     let wasmatic_address =
-                        load_wasmatic_address(&chain_config.wasmatic.endpoint).await?;
+                        load_wasmatic_address(&chain_info.wasmatic.endpoint).await?;
                     Address::try_from_value(&wasmatic_address, &chain_config.address_kind)?
                 }
                 _ => ctx.chain_config()?.parse_address(&addr_str)?,

--- a/tools/cli/src/config.rs
+++ b/tools/cli/src/config.rs
@@ -2,25 +2,9 @@ use anyhow::{Context, Result};
 use layer_climb::prelude::*;
 use serde::{Deserialize, Serialize};
 
-// This is the on-disk config
-// it's not the final config that gets filled in asynchrnously
-#[derive(Debug, Deserialize, Serialize)]
-pub struct OnDiskConfig {
-    pub chains: ChainConfigs,
-    pub faucet: FaucetConfig,
-    pub wasmatic: OnDiskWasmaticConfig,
-}
-#[derive(Debug, Deserialize, Serialize)]
-pub struct OnDiskWasmaticConfig {
-    pub endpoint: String,
-}
-
-// This is the actual, final config that gets used throughout the app
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     pub chains: ChainConfigs,
-    pub faucet: FaucetConfig,
-    pub wasmatic: WasmaticConfig,
 }
 
 impl Config {
@@ -28,44 +12,36 @@ impl Config {
     // but in theory this could be from chain, http endpoint, avs, etc.
     // internally, it does additional loads as needed (e.g. from wasmatic endpoint)
     pub async fn load() -> Result<Self> {
-        let config: OnDiskConfig = serde_json::from_str(include_str!("../config.json"))
+        let config: Config = serde_json::from_str(include_str!("../config.json"))
             .context("Failed to parse config")?;
 
         // SANITY CHECK
         // make sure every chain has the same address kind
 
-        let address_kind = match (&config.chains.local, &config.chains.testnet) {
+        match (&config.chains.local, &config.chains.testnet) {
             (Some(local), Some(testnet)) => {
                 if local.address_kind != testnet.address_kind {
                     return Err(anyhow::anyhow!(
                         "Local and testnet chains must have the same address kind"
                     ));
                 }
-
-                &local.address_kind
             }
-            (Some(local), None) => &local.address_kind,
-            (None, Some(testnet)) => &testnet.address_kind,
-            (None, None) => return Err(anyhow::anyhow!("At least one chain must be configured")),
-        };
-
-        let wasmatic_address = load_wasmatic_address(&config.wasmatic.endpoint).await?;
+            (None, None) => {
+                return Err(anyhow::anyhow!("At least one chain must be configured"));
+            }
+            _ => {} // Either local or testnet is Some, which is valid
+        }
 
         Ok(Config {
-            wasmatic: WasmaticConfig {
-                endpoint: config.wasmatic.endpoint,
-                address: match &address_kind {
-                    // TODO- this should be a method on AddrKind
-                    AddrKind::Cosmos { prefix } => {
-                        Address::new_cosmos_string(&wasmatic_address, Some(prefix))?
-                    }
-                    AddrKind::Eth => Address::new_eth_string(&wasmatic_address)?,
-                },
-            },
             chains: config.chains,
-            faucet: config.faucet,
         })
     }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ChainConfigs {
+    pub local: Option<ChainConfig>,
+    pub testnet: Option<ChainConfig>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -74,7 +50,7 @@ pub struct GetInfo {
     pub operators: Vec<String>,
 }
 
-async fn load_wasmatic_address(endpoint: &str) -> Result<String> {
+pub(crate) async fn load_wasmatic_address(endpoint: &str) -> Result<String> {
     let client = reqwest::Client::new();
 
     // Load from info endpoint
@@ -87,21 +63,4 @@ async fn load_wasmatic_address(endpoint: &str) -> Result<String> {
     let op = info.operators.first().context("No operators found")?;
 
     Ok(op.to_string())
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct WasmaticConfig {
-    pub endpoint: String,
-    pub address: Address,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct ChainConfigs {
-    pub local: Option<ChainConfig>,
-    pub testnet: Option<ChainConfig>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct FaucetConfig {
-    pub mnemonic: String,
 }

--- a/tools/cli/src/config.rs
+++ b/tools/cli/src/config.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
-    pub chains: ChainConfigs,
+    pub local: Option<ChainInfo>,
+    pub testnet: Option<ChainInfo>,
 }
 
 impl Config {
@@ -18,9 +19,9 @@ impl Config {
         // SANITY CHECK
         // make sure every chain has the same address kind
 
-        match (&config.chains.local, &config.chains.testnet) {
+        match (&config.local, &config.testnet) {
             (Some(local), Some(testnet)) => {
-                if local.address_kind != testnet.address_kind {
+                if local.chain.address_kind != testnet.chain.address_kind {
                     return Err(anyhow::anyhow!(
                         "Local and testnet chains must have the same address kind"
                     ));
@@ -32,16 +33,25 @@ impl Config {
             _ => {} // Either local or testnet is Some, which is valid
         }
 
-        Ok(Config {
-            chains: config.chains,
-        })
+        Ok(config)
     }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct ChainConfigs {
-    pub local: Option<ChainConfig>,
-    pub testnet: Option<ChainConfig>,
+pub struct ChainInfo {
+    pub chain: ChainConfig,
+    pub faucet: FaucetConfig,
+    pub wasmatic: WasmaticConfig,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct WasmaticConfig {
+    pub endpoint: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct FaucetConfig {
+    pub mnemonic: String,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/tools/cli/src/context.rs
+++ b/tools/cli/src/context.rs
@@ -76,7 +76,7 @@ impl AppContext {
     }
 
     pub async fn faucet_client(&self) -> Result<SigningClient> {
-        let signer = KeySigner::new_mnemonic_str(&self.config.faucet.mnemonic, None)?;
+        let signer = KeySigner::new_mnemonic_str(&self.chain_config()?.faucet.mnemonic, None)?;
         SigningClient::new(self.chain_config()?.clone(), signer).await
     }
 
@@ -86,7 +86,7 @@ impl AppContext {
             self.chain_config()?.clone(),
             // avoid accidentally trying to send funds to ourselves
             match self.args.concurrent_minimum_balance_from_faucet
-                && self.client_mnemonic()? == self.config.faucet.mnemonic
+                && self.client_mnemonic()? == self.chain_config()?.faucet.mnemonic
             {
                 true => Some(1),
                 false => None,

--- a/tools/cli/src/context.rs
+++ b/tools/cli/src/context.rs
@@ -7,7 +7,7 @@ use rand::{rngs::StdRng, SeedableRng};
 
 use crate::{
     args::{CliArgs, TargetEnvironment},
-    config::Config,
+    config::{ChainInfo, Config},
 };
 
 // The context is relatively cheap to clone, so we can pass it around
@@ -30,9 +30,13 @@ impl AppContext {
     }
 
     pub fn chain_config(&self) -> Result<&ChainConfig> {
+        self.chain_info().map(|ci| &ci.chain)
+    }
+
+    pub fn chain_info(&self) -> Result<&ChainInfo> {
         match self.args.target {
-            TargetEnvironment::Local => &self.config.chains.local,
-            TargetEnvironment::Testnet => &self.config.chains.testnet,
+            TargetEnvironment::Local => &self.config.local,
+            TargetEnvironment::Testnet => &self.config.testnet,
         }
         .as_ref()
         .context(format!(
@@ -76,7 +80,7 @@ impl AppContext {
     }
 
     pub async fn faucet_client(&self) -> Result<SigningClient> {
-        let signer = KeySigner::new_mnemonic_str(&self.chain_config()?.faucet.mnemonic, None)?;
+        let signer = KeySigner::new_mnemonic_str(&self.chain_info()?.faucet.mnemonic, None)?;
         SigningClient::new(self.chain_config()?.clone(), signer).await
     }
 
@@ -86,7 +90,7 @@ impl AppContext {
             self.chain_config()?.clone(),
             // avoid accidentally trying to send funds to ourselves
             match self.args.concurrent_minimum_balance_from_faucet
-                && self.client_mnemonic()? == self.chain_config()?.faucet.mnemonic
+                && self.client_mnemonic()? == self.chain_info()?.faucet.mnemonic
             {
                 true => Some(1),
                 false => None,

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -185,7 +185,7 @@ async fn main() -> Result<()> {
                     }
                 };
                 deploy(
-                    wasmatic_args.address,
+                    &ctx,
                     name,
                     digest,
                     wasm_source,
@@ -197,10 +197,10 @@ async fn main() -> Result<()> {
                 .await?;
             }
             WasmaticCommand::Remove { name } => {
-                remove(wasmatic_args.address, name).await?;
+                remove(&ctx, name).await?;
             }
             WasmaticCommand::Test { name, input } => {
-                test(wasmatic_args.address, name, input).await?;
+                test(&ctx, name, input).await?;
             }
         },
     }


### PR DESCRIPTION
Closes #59

The wasmatic address is not stored in the ChainConfig struct anymore, so we can simplify all of the structs to just use layer-climb-config's ChainConfig.

The wasmatic_address is now loaded from DeployContractArgs::parse instead of Config::load - avoiding unnecessary requests to the wasmatic endpoint.