### PR TITLE
CLI: Wasmatic: implement `/app` and `/info` entrypoints

### DIFF
--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -285,6 +285,9 @@ pub enum WasmaticCommand {
         #[clap(short, long)]
         input: Option<String>,
     },
+
+    /// Returns info about wasmatic operators
+    Info {},
 }
 
 #[derive(Copy, Clone, Debug, clap::ValueEnum)]

--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -288,6 +288,9 @@ pub enum WasmaticCommand {
 
     /// Returns info about wasmatic operators
     Info {},
+
+    /// Returns info deployed apps and sha256 digests
+    App {},
 }
 
 #[derive(Copy, Clone, Debug, clap::ValueEnum)]

--- a/tools/cli/src/args.rs
+++ b/tools/cli/src/args.rs
@@ -290,7 +290,10 @@ pub enum WasmaticCommand {
     Info {},
 
     /// Returns info deployed apps and sha256 digests
-    App {},
+    App {
+        #[clap(short, long)]
+        endpoint: Option<String>,
+    },
 }
 
 #[derive(Copy, Clone, Debug, clap::ValueEnum)]

--- a/tools/cli/src/commands/wasmatic.rs
+++ b/tools/cli/src/commands/wasmatic.rs
@@ -179,14 +179,11 @@ pub async fn info(ctx: &AppContext) -> Result<()> {
     let endpoints = &ctx.chain_info()?.wasmatic.endpoints;
     let client = Client::new();
 
-    // Make asynchronous requests to all endpoints
     futures::future::join_all(endpoints.iter().map(|endpoint| {
         let client = client.clone();
         async move {
-            // Send the GET request to `/info` endpoint
             let response = client.get(format!("{}/info", endpoint)).send().await?;
 
-            // Check if the request was successful
             if !response.status().is_success() {
                 bail!("Error: {:?}", response.text().await?);
             }
@@ -229,29 +226,23 @@ pub struct Queue {
     poll_interval: u32,
 }
 
-pub async fn app(ctx: &AppContext) -> Result<()> {
+pub async fn app(ctx: &AppContext, endpoint: Option<String>) -> Result<()> {
     let endpoints = &ctx.chain_info()?.wasmatic.endpoints;
     let client = Client::new();
 
-    // Call the first operator in the list (change this if you want to call a specific one)
-    let endpoint = &endpoints[0]; // You can also specify a different index
+    let endpoint = &endpoint.unwrap_or(endpoints[0].clone());
 
-    // Send the GET request to `/app` endpoint
     let response = client.get(format!("{}/app", endpoint)).send().await?;
 
-    // Check if the request was successful
     if !response.status().is_success() {
         bail!("Error: {:?}", response.text().await?);
     }
 
-    // Parse the response JSON into the structured format
     let app_response: AppResponse = response.json().await?;
-
-    // Print the structured response in a readable way
     println!(
         "Output for operator `{}`: {}",
         endpoint,
-        serde_json::to_string_pretty(&app_response)? // Pretty-print the response
+        serde_json::to_string_pretty(&app_response)?
     );
 
     Ok(())

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -225,8 +225,8 @@ async fn main() -> Result<()> {
             WasmaticCommand::Info {} => {
                 info(&ctx).await?;
             }
-            WasmaticCommand::App {} => {
-                app(&ctx).await?;
+            WasmaticCommand::App { endpoint } => {
+                app(&ctx, endpoint).await?;
             }
         },
     }

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -10,7 +10,7 @@ use commands::{
     deploy::{deploy_contracts, DeployContractArgs},
     faucet::tap_faucet,
     task_queue::TaskQueue,
-    wasmatic::{deploy, info, remove, run, test, Trigger},
+    wasmatic::{app, deploy, info, remove, run, test, Trigger},
 };
 use context::AppContext;
 use layer_climb::prelude::*;
@@ -224,6 +224,9 @@ async fn main() -> Result<()> {
             }
             WasmaticCommand::Info {} => {
                 info(&ctx).await?;
+            }
+            WasmaticCommand::App {} => {
+                app(&ctx).await?;
             }
         },
     }

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -10,7 +10,7 @@ use commands::{
     deploy::{deploy_contracts, DeployContractArgs},
     faucet::tap_faucet,
     task_queue::TaskQueue,
-    wasmatic::{deploy, remove, run, test, Trigger},
+    wasmatic::{deploy, info, remove, run, test, Trigger},
 };
 use context::AppContext;
 use layer_climb::prelude::*;
@@ -221,6 +221,9 @@ async fn main() -> Result<()> {
             }
             WasmaticCommand::Test { name, input } => {
                 test(&ctx, name, input).await?;
+            }
+            WasmaticCommand::Info {} => {
+                info(&ctx).await?;
             }
         },
     }


### PR DESCRIPTION
closes #58 
Implements `/app` and `info` entrypoints to the wasmatic section of the CLI.
For `/info` it runs in a loop for all of the endpoints, for `/app` it takes just the first one.

```
$ cargo run -- wasmatic info

Output for operator `https://op3.layer-p.net`: {
  "operators": [
    "layer1cdjph3vh5egrg0kruhxcschcy4prd05k8j9xyc",
    "layer1ks6c5jerth4gfw4pndu04vga32cg8wvc3ea580",
    "layer1wq5kw9ydjmqaw70udkf78fv8ltzhn9mh9fsd34",
    "layer1n5n8yarh6rwv9dgrry0pall9vuef4zt0mg7y2k",
    "layer164z0yxp53fn7n3vs0u3dahh2qds5665qedutxc"
  ]
}
Output for operator `https://op1.layer-p.net`: {
  "operators": [
    "layer1qyfn9l7w78kxcerwwwc6dpad305dulhk9jks0r",
    "layer1t5tjn9ycw7yj78nqq0nv8mn8rncs0tp93fxjmq",
    "layer1adv6jj7wdzpt3y65n3lv3ac72pahf34qa3ar69",
    "layer1kw6wf7sw2ngqx9j9c0zs8tdgx9nd58l8edynxu",
    "layer1h669kj0n08dtf7gupndsu6sl2w9ynmfjftp385"
  ]
}
Output for operator `https://op2.layer-p.net`: {
  "operators": [
    "layer1fx03sfs9tep8e63r3lf0as658epzg3fgsdgw0q",
    "layer1xgvmadqyjuwdhp8epge2kkzzcmgc0yqgny0v7r",
    "layer14fhyuh4h8amjykx3hn5uef5hr8pxp5pejhy9la",
    "layer1634ujmw69a7lphdd4xdn29s2ts6phaxllcw74n",
    "layer1kf503yw72yvsxtqvwk7sw08cq362prqqys0yf7"
  ]
}

$ cargo run -- wasmatic app

Output for operator `https://op1.layer-p.net`: {
  "apps": [
    {
      "name": "YOUR_NAME_HERE",
      "digest": "sha256:d902444dcc241c6d19fefbdaf2e34d3d88d17453f11450ae605c4e9357c5bd14",
      "trigger": {
        "queue": {
          "taskQueueAddr": "layer14wx6ax8tqtvh3mra9f0xswdhh8jjrx63qs5ahqnjzlvu8sps2p7qfeevdw",
          "hdIndex": 0,
          "pollInterval": 3
        }
      },
      "permissions": {},
      "testable": true
    },
  "digests": [
    "sha256:cec7675a967bc7175cdb7484cc72372d07bc7da3beb9310f37c2000c5fd8431d"
  ]
}
```