### PR TITLE
Parse address validity

### DIFF
--- a/tools/cli/src/commands/wasmatic.rs
+++ b/tools/cli/src/commands/wasmatic.rs
@@ -1,7 +1,7 @@
 use super::wasmatic_cron_bindings as cron_bindings;
 use super::wasmatic_task_bindings as task_bindings;
 use anyhow::{bail, Context, Result};
-use layer_climb::prelude::Address;
+use layer_climb::prelude::*;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -48,7 +48,9 @@ pub async fn deploy(
         task_queue_addr, ..
     } = &trigger
     {
-        let address = Address::new_cosmos_string(task_queue_addr, None)
+        let address = ctx
+            .chain_config()?
+            .parse_address(task_queue_addr)
             .context(format!("Invalid Task Address: `{task_queue_addr}`"))?;
         ctx.query_client()
             .await?

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -175,11 +175,15 @@ async fn main() -> Result<()> {
             } => {
                 let trigger = match (cron_trigger, task_trigger) {
                     (Some(cron), None) => Trigger::Cron { schedule: cron },
-                    (None, Some(task)) => Trigger::Queue {
-                        task_queue_addr: task,
-                        hd_index,
-                        poll_interval,
-                    },
+                    (None, Some(task)) => {
+                        Address::new_cosmos_string(&task, None)
+                            .expect("Invalid Task Address {task}");
+                        Trigger::Queue {
+                            task_queue_addr: task,
+                            hd_index,
+                            poll_interval,
+                        }
+                    }
                     _ => {
                         panic!("Error: You need to provide either cron_trigger or task_trigger")
                     }

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -175,15 +175,11 @@ async fn main() -> Result<()> {
             } => {
                 let trigger = match (cron_trigger, task_trigger) {
                     (Some(cron), None) => Trigger::Cron { schedule: cron },
-                    (None, Some(task)) => {
-                        Address::new_cosmos_string(&task, None)
-                            .expect("Invalid Task Address {task}");
-                        Trigger::Queue {
-                            task_queue_addr: task,
-                            hd_index,
-                            poll_interval,
-                        }
-                    }
+                    (None, Some(task)) => Trigger::Queue {
+                        task_queue_addr: task,
+                        hd_index,
+                        poll_interval,
+                    },
                     _ => {
                         panic!("Error: You need to provide either cron_trigger or task_trigger")
                     }


### PR DESCRIPTION
Checks if address is valid address and errors if invalid.
Also checks if contract is found on chain and errors if not.

Provides desired erroring described in https://github.com/Lay3rLabs/avs-toolkit/issues/95, but is not a fix for breakage described, as breakage is not reproduced via issue description.

