### PR TITLE
moves handle_metadata() into TasksStorage

### DIFF
--- a/contracts/oracle-verifier/src/error.rs
+++ b/contracts/oracle-verifier/src/error.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{Decimal, StdError};
 use cw_utils::PaymentError;
-use lavs_helpers::verifier::VerifierError;
+use lavs_apis::verifier_simple::helper::VerifierError;
 use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum ContractError {

--- a/contracts/oracle-verifier/src/error.rs
+++ b/contracts/oracle-verifier/src/error.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{Decimal, StdError};
 use cw_utils::PaymentError;
-use lavs_apis::verifier_simple::helper::VerifierError;
+use lavs_apis::verifier_simple::VerifierError;
 use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum ContractError {

--- a/contracts/verifier-simple/src/error.rs
+++ b/contracts/verifier-simple/src/error.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::StdError;
 use cw_utils::PaymentError;
-use lavs_helpers::verifier::VerifierError;
+use lavs_apis::verifier_simple::helper::VerifierError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/contracts/verifier-simple/src/error.rs
+++ b/contracts/verifier-simple/src/error.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::StdError;
 use cw_utils::PaymentError;
-use lavs_apis::verifier_simple::helper::VerifierError;
+use lavs_apis::verifier_simple::VerifierError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/packages/apis/src/interfaces/tasks.rs
+++ b/packages/apis/src/interfaces/tasks.rs
@@ -9,7 +9,7 @@ use cw_storage_plus::Map;
 use crate::{
     id::TaskId,
     tasks::Status,
-    verifier_simple::{helper::VerifierError, TaskMetadata},
+    verifier_simple::{TaskMetadata, VerifierError},
 };
 
 use crate::interfaces::voting::QueryMsg as OperatorQueryMsg;

--- a/packages/apis/src/interfaces/tasks.rs
+++ b/packages/apis/src/interfaces/tasks.rs
@@ -2,11 +2,19 @@
 /// by other contracts. This specifies the required APIs for on-chain interactions.
 /// This must be a subset of any of the implementation.
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, StdResult, Storage, Timestamp};
+use cosmwasm_std::{Addr, Decimal, DepsMut, Env, StdResult, Storage, Timestamp};
 use cw_orch::{ExecuteFns, QueryFns};
 use cw_storage_plus::Map;
 
-use crate::{id::TaskId, tasks::Status, verifier_simple::TaskMetadata};
+use crate::{
+    id::TaskId,
+    tasks::Status,
+    verifier_simple::{helper::VerifierError, TaskMetadata},
+};
+
+use crate::interfaces::voting::QueryMsg as OperatorQueryMsg;
+
+use super::voting::TotalPowerResponse;
 
 // FIXME: hot to make these generic
 pub type ResponseType = serde_json::Value;
@@ -37,6 +45,68 @@ impl<'a> TasksStorage<'a> {
     ) -> StdResult<()> {
         self.0.save(store, key, &metadata)?;
         Ok(())
+    }
+
+    pub fn handle_metadata(
+        deps: DepsMut,
+        env: &Env,
+        operator_addr: &Addr,
+        task_queue: &Addr,
+        task_id: TaskId,
+        fraction_percent: u32,
+    ) -> Result<TaskMetadata, VerifierError> {
+        let tasks_storage = TasksStorage::new("tasks");
+        let metadata = tasks_storage.get_tasks(deps.storage, (task_queue, task_id))?;
+
+        match metadata {
+            Some(meta) => {
+                // Ensure this is not yet expired (or completed)
+                match meta.status {
+                    TaskStatus::Completed => Err(VerifierError::TaskAlreadyCompleted),
+                    TaskStatus::Expired => Err(VerifierError::TaskExpired),
+                    TaskStatus::Open if meta.is_expired(env) => Err(VerifierError::TaskExpired),
+                    _ => Ok(meta.clone()),
+                }
+            }
+            None => {
+                // We need to query the info from the task queue
+                let task_status: TaskStatusResponse = deps.querier.query_wasm_smart(
+                    task_queue.to_string(),
+                    &TaskQueryMsg::TaskStatus { id: task_id },
+                )?;
+                // Abort early if not still open
+                match task_status.status {
+                    TaskStatus::Completed => Err(VerifierError::TaskAlreadyCompleted),
+                    TaskStatus::Expired => Err(VerifierError::TaskExpired),
+                    TaskStatus::Open => {
+                        // If we create this, we need to calculate total vote power needed
+                        let total_power: TotalPowerResponse = deps.querier.query_wasm_smart(
+                            operator_addr.to_string(),
+                            &OperatorQueryMsg::TotalPowerAtHeight {
+                                height: Some(task_status.created_height),
+                            },
+                        )?;
+                        // need to round up!
+                        // NOTE: for now we are using percentage, with oracle-verifier
+                        // this would change
+                        let fraction = Decimal::percent(fraction_percent as u64);
+                        let power_required = total_power.power.mul_ceil(fraction);
+                        let meta = TaskMetadata {
+                            power_required,
+                            status: TaskStatus::Open,
+                            created_height: task_status.created_height,
+                            expires_time: task_status.expires_time,
+                        };
+                        tasks_storage.save_tasks(
+                            deps.storage,
+                            (task_queue, task_id),
+                            meta.clone(),
+                        )?;
+                        Ok(meta)
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/packages/apis/src/verifier_simple.rs
+++ b/packages/apis/src/verifier_simple.rs
@@ -144,3 +144,34 @@ mod deployment {
         }
     }
 }
+
+pub mod helper {
+    use cosmwasm_std::StdError;
+    use cw_utils::PaymentError;
+    use thiserror::Error;
+
+    #[derive(Error, Debug)]
+    pub enum VerifierError {
+        #[error("{0}")]
+        Std(#[from] StdError),
+
+        #[error("{0}")]
+        Payment(#[from] PaymentError),
+        #[error("Invalid percentage, must be between 1 and 100")]
+        InvalidPercentage,
+
+        #[error("Operator tried to vote twice: {0}")]
+        OperatorAlreadyVoted(String),
+
+        #[error("Task expired. Cannot vote on it")]
+        TaskExpired,
+
+        #[error("Task already completed. Cannot vote on it")]
+        TaskAlreadyCompleted,
+
+        #[error("Unauthorized")]
+        Unauthorized,
+        // Add any other custom errors you like here.
+        // Look at https://docs.rs/thiserror/1.0.21/thiserror/ for details.
+    }
+}

--- a/packages/helpers/src/verifier.rs
+++ b/packages/helpers/src/verifier.rs
@@ -1,43 +1,11 @@
-use cosmwasm_std::{Addr, Decimal, DepsMut, Env, StdError, Uint128};
-use cw_utils::PaymentError;
+use cosmwasm_std::{Addr, DepsMut, Env, Uint128};
 use lavs_apis::{
     id::TaskId,
-    interfaces::{
-        tasks::TasksStorage,
-        voting::{TotalPowerResponse, VotingPowerResponse},
-    },
-    tasks::{TaskQueryMsg, TaskStatus, TaskStatusResponse},
-    verifier_simple::TaskMetadata,
+    interfaces::{tasks::TasksStorage, voting::VotingPowerResponse},
+    verifier_simple::{helper::VerifierError, TaskMetadata},
 };
 
 use lavs_apis::interfaces::voting::QueryMsg as OperatorQueryMsg;
-use thiserror::Error;
-
-#[derive(Error, Debug)]
-pub enum VerifierError {
-    #[error("{0}")]
-    Std(#[from] StdError),
-
-    #[error("{0}")]
-    Payment(#[from] PaymentError),
-
-    #[error("Invalid percentage, must be between 1 and 100")]
-    InvalidPercentage,
-
-    #[error("Operator tried to vote twice: {0}")]
-    OperatorAlreadyVoted(String),
-
-    #[error("Task expired. Cannot vote on it")]
-    TaskExpired,
-
-    #[error("Task already completed. Cannot vote on it")]
-    TaskAlreadyCompleted,
-
-    #[error("Unauthorized")]
-    Unauthorized,
-    // Add any other custom errors you like here.
-    // Look at https://docs.rs/thiserror/1.0.21/thiserror/ for details.
-}
 
 /// Does all checks to ensure the voter is valid and has not voted yet.
 /// Also checks the task is valid and still open.
@@ -57,7 +25,7 @@ pub fn ensure_valid_vote(
 ) -> Result<Option<(TaskMetadata, Uint128)>, VerifierError> {
     // Load task info, or create it if not there
     // Error here means the contract is in expired or completed, return None rather than error
-    let metadata = match handle_metadata(
+    let metadata = match TasksStorage::<'_>::handle_metadata(
         deps.branch(),
         env,
         operators_addr,
@@ -82,62 +50,4 @@ pub fn ensure_valid_vote(
     }
 
     Ok(Some((metadata, power.power)))
-}
-
-fn handle_metadata(
-    deps: DepsMut,
-    env: &Env,
-    operator_addr: &Addr,
-    task_queue: &Addr,
-    task_id: TaskId,
-    fraction_percent: u32,
-) -> Result<TaskMetadata, VerifierError> {
-    let tasks_storage = TasksStorage::new("tasks");
-    let metadata = tasks_storage.get_tasks(deps.storage, (task_queue, task_id))?;
-
-    match metadata {
-        Some(meta) => {
-            // Ensure this is not yet expired (or completed)
-            match meta.status {
-                TaskStatus::Completed => Err(VerifierError::TaskAlreadyCompleted),
-                TaskStatus::Expired => Err(VerifierError::TaskExpired),
-                TaskStatus::Open if meta.is_expired(env) => Err(VerifierError::TaskExpired),
-                _ => Ok(meta.clone()),
-            }
-        }
-        None => {
-            // We need to query the info from the task queue
-            let task_status: TaskStatusResponse = deps.querier.query_wasm_smart(
-                task_queue.to_string(),
-                &TaskQueryMsg::TaskStatus { id: task_id },
-            )?;
-            // Abort early if not still open
-            match task_status.status {
-                TaskStatus::Completed => Err(VerifierError::TaskAlreadyCompleted),
-                TaskStatus::Expired => Err(VerifierError::TaskExpired),
-                TaskStatus::Open => {
-                    // If we create this, we need to calculate total vote power needed
-                    let total_power: TotalPowerResponse = deps.querier.query_wasm_smart(
-                        operator_addr.to_string(),
-                        &OperatorQueryMsg::TotalPowerAtHeight {
-                            height: Some(task_status.created_height),
-                        },
-                    )?;
-                    // need to round up!
-                    // NOTE: for now we are using percentage, with oracle-verifier
-                    // this would change
-                    let fraction = Decimal::percent(fraction_percent as u64);
-                    let power_required = total_power.power.mul_ceil(fraction);
-                    let meta = TaskMetadata {
-                        power_required,
-                        status: TaskStatus::Open,
-                        created_height: task_status.created_height,
-                        expires_time: task_status.expires_time,
-                    };
-                    tasks_storage.save_tasks(deps.storage, (task_queue, task_id), meta.clone())?;
-                    Ok(meta)
-                }
-            }
-        }
-    }
 }

--- a/packages/helpers/src/verifier.rs
+++ b/packages/helpers/src/verifier.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{Addr, DepsMut, Env, Uint128};
 use lavs_apis::{
     id::TaskId,
     interfaces::{tasks::TasksStorage, voting::VotingPowerResponse},
-    verifier_simple::{helper::VerifierError, TaskMetadata},
+    verifier_simple::{TaskMetadata, VerifierError},
 };
 
 use lavs_apis::interfaces::voting::QueryMsg as OperatorQueryMsg;


### PR DESCRIPTION
- moves the handle_metadata() function into the implementation block of TasksStorage.
- changes ensure_valid_vote() to use the new method.
- Moves the Verifier helper errors into APIs so they can be reused throughout the project.