### PR TITLE
added unified list query to task queue

### DIFF
--- a/contracts/task-queue/README.md
+++ b/contracts/task-queue/README.md
@@ -42,8 +42,9 @@ Anyone can call to mark a task as timed out if the block time has passed the tas
 
 ## Queries
 
-- List open tasks (oldest first)
-- List closed tasks (most recently closed first)
+- List all tasks (most recently created first)
+- List open tasks (most recently created first)
+- List closed tasks (most recently created first)
 - Get Task info by id (included status and result if any)
 
 ## Data

--- a/contracts/task-queue/src/contract.rs
+++ b/contracts/task-queue/src/contract.rs
@@ -342,13 +342,15 @@ mod query {
             )
             .map(|r| {
                 r.map(|(id, task)| {
-                    // add expires timestamp to status open enum
+                    // add timestamps to status enum
                     let status = match task.validate_status(&env) {
                         Status::Open {} => InfoStatus::Open {
                             expires: task.timing.expires_at,
                         },
                         Status::Completed { completed, .. } => InfoStatus::Completed { completed },
-                        Status::Expired {} => InfoStatus::Expired {},
+                        Status::Expired {} => InfoStatus::Expired {
+                            expired: task.timing.expires_at,
+                        },
                     };
 
                     TaskInfoResponse {

--- a/contracts/task-queue/src/contract.rs
+++ b/contracts/task-queue/src/contract.rs
@@ -71,6 +71,12 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
         },
         QueryMsg::Custom(custom) => match custom {
             CustomQueryMsg::Task { id } => Ok(to_json_binary(&query::task(deps, env, id)?)?),
+            CustomQueryMsg::List { start_after, limit } => Ok(to_json_binary(&query::list(
+                deps,
+                env,
+                start_after,
+                limit,
+            )?)?),
             CustomQueryMsg::ListOpen { start_after, limit } => Ok(to_json_binary(
                 &query::list_open(deps, env, start_after, limit)?,
             )?),
@@ -270,8 +276,8 @@ mod query {
     use lavs_apis::{id::TaskId, tasks::ConfigResponse};
 
     use crate::msg::{
-        CompletedTaskOverview, ListCompletedResponse, ListOpenResponse, OpenTaskOverview,
-        TaskResponse, TaskStatusResponse,
+        CompletedTaskOverview, InfoStatus, ListCompletedResponse, ListOpenResponse, ListResponse,
+        OpenTaskOverview, TaskInfoResponse, TaskResponse, TaskStatusResponse,
     };
 
     use super::*;
@@ -319,6 +325,48 @@ mod query {
     }
 
     // TODO: There should probably be a max page limit, but it's left unbound to keep the API simple for now
+    pub fn list(
+        deps: Deps,
+        env: Env,
+        start_after: Option<TaskId>,
+        limit: Option<u32>,
+    ) -> Result<ListResponse, ContractError> {
+        let limit = limit.map(|v| v as usize).unwrap_or(usize::MAX);
+
+        let tasks = TASKS
+            .range(
+                deps.storage,
+                None,
+                start_after.map(Bound::exclusive),
+                cosmwasm_std::Order::Descending,
+            )
+            .map(|r| {
+                r.map(|(id, task)| {
+                    // add expires timestamp to status open enum
+                    let status = match task.validate_status(&env) {
+                        Status::Open {} => InfoStatus::Open {
+                            expires: task.timing.expires_at,
+                        },
+                        Status::Completed { completed, .. } => InfoStatus::Completed { completed },
+                        Status::Expired {} => InfoStatus::Expired {},
+                    };
+
+                    TaskInfoResponse {
+                        id,
+                        description: task.description,
+                        status,
+                        payload: task.payload,
+                        result: task.result,
+                        created_at: task.timing.created_at,
+                    }
+                })
+            })
+            .take(limit)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(ListResponse { tasks })
+    }
+
     pub fn list_open(
         deps: Deps,
         env: Env,

--- a/contracts/task-queue/src/tests/common.rs
+++ b/contracts/task-queue/src/tests/common.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use crate::error::ContractError;
 use crate::interface::Contract as TaskContract;
 use crate::msg::{
-    CompletedTaskOverview, InstantiateMsg, ListCompletedResponse, ListOpenResponse,
+    CompletedTaskOverview, InstantiateMsg, ListCompletedResponse, ListOpenResponse, ListResponse,
     OpenTaskOverview, Requestor, Status, TimeoutInfo,
 };
 use crate::tests::multi::DENOM;
@@ -225,6 +225,9 @@ where
     let ListOpenResponse { tasks } = contract.list_open(None, None).unwrap();
     assert_eq!(tasks.len(), 3);
 
+    let ListResponse { tasks: all_tasks } = contract.list(None, None).unwrap();
+    assert_eq!(all_tasks.len(), 3);
+
     let calculate_expiration =
         |start: Timestamp, n_blocks: u64, timeout_seconds: u64| -> Timestamp {
             let duration = Duration::new_seconds(n_blocks * block_time + offset + timeout_seconds);
@@ -279,6 +282,9 @@ where
     chain.wait_seconds(100).unwrap();
     let ListOpenResponse { tasks } = contract.list_open(None, None).unwrap();
     assert_eq!(tasks.len(), 0);
+
+    let ListResponse { tasks: all_tasks } = contract.list(None, None).unwrap();
+    assert_eq!(all_tasks.len(), 3);
 }
 
 pub fn completion_works<C>(chain: C)
@@ -297,6 +303,10 @@ where
     // list completed empty
     let ListCompletedResponse { tasks } = contract.list_completed(None, None).unwrap();
     assert_eq!(tasks.len(), 0);
+
+    // two total tasks exist
+    let ListResponse { tasks: all_tasks } = contract.list(None, None).unwrap();
+    assert_eq!(all_tasks.len(), 2);
 
     // normal user cannot complete
     let err = contract.complete(one, result.clone()).unwrap_err();
@@ -361,6 +371,10 @@ where
             result,
         }
     );
+
+    // two total tasks still exist
+    let ListResponse { tasks: all_tasks } = contract.list(None, None).unwrap();
+    assert_eq!(all_tasks.len(), 2);
 }
 
 pub fn task_status_works<C>(chain: C)

--- a/packages/apis/src/tasks.rs
+++ b/packages/apis/src/tasks.rs
@@ -109,13 +109,19 @@ pub enum QueryMsg {
 #[cw_orch(disable_fields_sorting)]
 #[derive(QueryResponses)]
 pub enum CustomQueryMsg {
-    /// Ordered by expiration time ascending
+    /// List all tasks, ordered descending by task ID
+    #[returns(ListResponse)]
+    List {
+        start_after: Option<TaskId>,
+        limit: Option<u32>,
+    },
+    /// List open tasks, ordered descending by task ID
     #[returns(ListOpenResponse)]
     ListOpen {
         start_after: Option<TaskId>,
         limit: Option<u32>,
     },
-    /// Ordered by completion time descending (last completed first)
+    /// List completed tasks, ordered descending by task ID
     #[returns(ListCompletedResponse)]
     ListCompleted {
         start_after: Option<TaskId>,
@@ -142,6 +148,30 @@ impl From<CustomQueryMsg> for QueryMsg {
     fn from(value: CustomQueryMsg) -> Self {
         Self::Custom(value)
     }
+}
+
+/// This is detailed information about a task for listing, including the
+/// payload, result, and timing information.
+#[cw_serde]
+pub struct TaskInfoResponse {
+    pub id: TaskId,
+    pub description: String,
+    pub status: InfoStatus,
+    pub payload: RequestType,
+    pub result: Option<ResponseType>,
+    pub created_at: Timestamp,
+}
+
+#[cw_serde]
+pub enum InfoStatus {
+    Open { expires: Timestamp },
+    Completed { completed: Timestamp },
+    Expired {},
+}
+
+#[cw_serde]
+pub struct ListResponse {
+    pub tasks: Vec<TaskInfoResponse>,
 }
 
 #[cw_serde]

--- a/packages/apis/src/tasks.rs
+++ b/packages/apis/src/tasks.rs
@@ -166,7 +166,7 @@ pub struct TaskInfoResponse {
 pub enum InfoStatus {
     Open { expires: Timestamp },
     Completed { completed: Timestamp },
-    Expired {},
+    Expired { expired: Timestamp },
 }
 
 #[cw_serde]


### PR DESCRIPTION
Resolves #110 

This adds a new `List` query to the task queue contract which retrieves tasks of both open and completed statuses.