### PR TITLE
DO NOT MERGE: Adjustments to work with wasmatic API 2.0

### DIFF
--- a/tools/shared/src/wasmatic.rs
+++ b/tools/shared/src/wasmatic.rs
@@ -30,7 +30,7 @@ pub async fn deploy(
     digest: Option<String>,
     wasm_file: WasmFile,
     trigger: Trigger,
-    permissions: impl Serialize,
+    _permissions: impl Serialize,
     envs: Vec<(String, String)>,
     testable: bool,
     on_deploy_success: impl Fn(&str),
@@ -50,6 +50,12 @@ pub async fn deploy(
             .context(format!("Contract Not Found: `{task_queue_addr}`"))?;
     }
 
+    // TODO: make this default in wasmatic if the fields are not provided
+    let permissions = json!({
+        "allowedHttpHosts": "all",
+        "fileSystem": true,
+    });
+
     // Prepare the JSON body
     let body = json!({
         "name": name,
@@ -58,6 +64,7 @@ pub async fn deploy(
         "envs": envs,
         "testable": testable,
     });
+    println!("body {:?}", body);
 
     // Check if wasm_source is a URL or a local file path
     let json_body = match wasm_file {
@@ -81,7 +88,7 @@ pub async fn deploy(
             let mut hasher = Sha256::new();
             hasher.update(&wasm_binary);
             let result = hasher.finalize();
-            json_body["digest"] = json!(format!("sha256:{:x}", result));
+            json_body["digest"] = json!(format!("{:x}", result));
 
             futures::future::join_all(endpoints.iter().map(|endpoint| {
                 let http_client = http_client.clone();


### PR DESCRIPTION
This is needed for first testing, we will address fixes in https://github.com/Lay3rLabs/wasmatic/pull/125 so we can use the v0.2.0 tag

We probably want to change wasmatic API to make these unnecessary, but in the meantime, they are needed for testing:

- Fill out default values in permissions (let's assign all priviledges if nothing specified for now)
- Digest is prefixed by `sha256:` before hex digits. I don't like that internally, but we can strip that off in the API for now

Also note that I need to add MATIC_E2E_MNEMONIC not just MATIC_SUBMISSION_MNEMONIC.

To reproduce, pull latest commit from https://github.com/Lay3rLabs/my-layer/pull/3 and in one terminal:

```bash
./localnode/reset_volumes.sh
./localnode/run.sh
docker logs -f localnode-wasmatic-1
```

In the other terminal, check out this PR and follow the instructions in DEMO.md **from the my-layer repo** (which targets localnode)